### PR TITLE
Bugfix empty integration

### DIFF
--- a/api/src/main/java/io/kaoto/backend/api/resource/IntegrationResource.java
+++ b/api/src/main/java/io/kaoto/backend/api/resource/IntegrationResource.java
@@ -4,7 +4,7 @@ import io.kaoto.backend.api.resource.request.DeploymentResourceYamlRequest;
 import io.kaoto.backend.api.service.deployment.DeploymentService;
 import io.kaoto.backend.deployment.ClusterService;
 import io.kaoto.backend.model.deployment.Integration;
-import io.smallrye.config.ConfigMapping;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
@@ -53,11 +53,7 @@ public class IntegrationResource {
         this.clusterService = clusterService;
     }
 
-    public void setCrdDefault(final String crdDefault) {
-        this.crdDefault = crdDefault;
-    }
-
-    @ConfigMapping(prefix = "crd.default")
+    @ConfigProperty(name = "crd.default")
     private String crdDefault;
     private DeploymentService deploymentService;
     private ClusterService clusterService;
@@ -111,14 +107,20 @@ public class IntegrationResource {
             final @QueryParam("type") String type) {
         Map<String, String> crds = customResourcesDefinition(request);
 
+        log.trace("Found " + crds.size() + " potential CRDs.");
+
         if (crds.containsKey(type)) {
+            log.trace("Returning type " + type);
             return crds.get(type);
         }
 
+        log.trace("Trying to return default type " + crdDefault);
         if (crds.containsKey(crdDefault)) {
+            log.trace("Returning default " + crdDefault);
             return crds.get(crdDefault);
         }
 
+        log.trace("Returning arbitrary one.");
         return crds.values().iterator().next();
     }
 

--- a/api/src/main/java/io/kaoto/backend/api/resource/ViewDefinitionResource.java
+++ b/api/src/main/java/io/kaoto/backend/api/resource/ViewDefinitionResource.java
@@ -108,16 +108,4 @@ public class ViewDefinitionResource {
                 .type(MediaType.TEXT_PLAIN_TYPE)
                 .build();
     }
-
-    @ServerExceptionMapper
-    public Response mapException(final IllegalArgumentException x) {
-        log.error("Error trying to return YAML.", x);
-
-        return Response.status(Response.Status.BAD_REQUEST)
-                .entity("Couldn't parse the YAML provided: "
-                        + x.getMessage())
-                .type(MediaType.TEXT_PLAIN_TYPE)
-                .build();
-    }
-
 }

--- a/api/src/main/java/io/kaoto/backend/api/resource/ViewDefinitionResource.java
+++ b/api/src/main/java/io/kaoto/backend/api/resource/ViewDefinitionResource.java
@@ -83,9 +83,14 @@ public class ViewDefinitionResource {
         ViewDefinitionResourceResponse res =
                 new ViewDefinitionResourceResponse();
         for (StepParserService<Step> stepParserService : stepParserServices) {
-            if (stepParserService.appliesTo(crd)) {
-                res.setSteps(stepParserService.parse(crd));
-                break;
+            try {
+                if (stepParserService.appliesTo(crd)) {
+                    res.setSteps(stepParserService.parse(crd));
+                    break;
+                }
+            } catch (Exception e) {
+                log.warn("Parser " + stepParserService.getClass() + "threw an"
+                        + " unexpected error.", e);
             }
         }
         res.setViews(viewDefinitionService.views(crd, res.getSteps()));

--- a/api/src/main/java/io/kaoto/backend/api/service/deployment/DeploymentService.java
+++ b/api/src/main/java/io/kaoto/backend/api/service/deployment/DeploymentService.java
@@ -2,6 +2,7 @@ package io.kaoto.backend.api.service.deployment;
 
 import io.kaoto.backend.api.service.deployment.generator.DeploymentGeneratorService;
 import io.kaoto.backend.model.step.Step;
+import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
@@ -17,6 +18,8 @@ import java.util.Map;
  */
 @ApplicationScoped
 public class DeploymentService {
+
+    private Logger log = Logger.getLogger(DeploymentService.class);
 
     @Inject
     private Instance<DeploymentGeneratorService> parsers;
@@ -34,8 +37,14 @@ public class DeploymentService {
         Map<String, String> strings = new HashMap<>();
 
         for (DeploymentGeneratorService parser : getParsers()) {
-            if (parser.appliesTo(steps)) {
-                strings.put(parser.identifier(), parser.parse(name, steps));
+            try {
+                if (parser.appliesTo(steps)) {
+                    strings.put(parser.identifier(), parser.parse(name, steps));
+                }
+            } catch (Exception e) {
+                log.warn("Parser " + parser.getClass() + "threw an unexpected"
+                                + " error. ",
+                        e);
             }
         }
 

--- a/api/src/main/java/io/kaoto/backend/api/service/viewdefinition/ViewDefinitionService.java
+++ b/api/src/main/java/io/kaoto/backend/api/service/viewdefinition/ViewDefinitionService.java
@@ -38,11 +38,13 @@ public class ViewDefinitionService {
                                       final List<Step> steps) {
 
         int i = 0;
-        for (Step step : steps) {
-            if (step != null) {
-                step.setUUID(i + step.getId());
+        if (steps != null) {
+            for (Step step : steps) {
+                if (step != null) {
+                    step.setUUID(i + step.getId());
+                }
+                i++;
             }
-            i++;
         }
 
         List<ViewDefinition> viewDefinitions = new ArrayList<>();

--- a/api/src/main/java/io/kaoto/backend/api/service/viewdefinition/ViewDefinitionService.java
+++ b/api/src/main/java/io/kaoto/backend/api/service/viewdefinition/ViewDefinitionService.java
@@ -45,6 +45,7 @@ public class ViewDefinitionService {
                 }
                 i++;
             }
+            log.trace("Found " + steps.size() + " steps.");
         }
 
         List<ViewDefinition> viewDefinitions = new ArrayList<>();

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -19,3 +19,9 @@ quarkus:
   http:
     test-port: 8083
     cors: true
+  log:
+    category:
+      io.kaoto.backend.api:
+        level: "TRACE"
+      org.ecl.yas.int:
+        level: "INFO"

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -22,6 +22,6 @@ quarkus:
   log:
     category:
       io.kaoto.backend.api:
-        level: "TRACE"
+        level: "INFO"
       org.ecl.yas.int:
         level: "INFO"

--- a/api/src/test/java/io/kaoto/backend/api/resource/ViewDefinitionResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/ViewDefinitionResourceTest.java
@@ -71,16 +71,4 @@ class ViewDefinitionResourceTest {
                 .statusCode(Response.Status
                         .UNSUPPORTED_MEDIA_TYPE.getStatusCode());
     }
-
-    @Test
-    void testExceptions() {
-        given()
-                .when()
-                .body("kind: KameletBinding : wrong invalid content")
-                .contentType("text/yaml")
-                .post()
-                .then()
-                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
-    }
-
 }

--- a/api/src/test/java/io/kaoto/backend/api/service/deployment/generator/KameletBindingDeploymentGeneratorServiceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/service/deployment/generator/KameletBindingDeploymentGeneratorServiceTest.java
@@ -14,6 +14,23 @@ import java.util.List;
 @QuarkusTest
 class KameletBindingDeploymentGeneratorServiceTest {
 
+    public static final String EMPTY_INTEGRATION =
+            "apiVersion: camel.apache.org/v1alpha1\n"
+                    + "group: camel.apache.org\n"
+                    + "kind: KameletBinding\n"
+                    + "metadata:\n"
+                    + "  additionalProperties: {}\n"
+                    + "  finalizers: []\n"
+                    + "  managedFields: []\n"
+                    + "  name: ''\n"
+                    + "  ownerReferences: []\n"
+                    + "plural: kameletbindings\n"
+                    + "scope: Namespaced\n"
+                    + "served: true\n"
+                    + "singular: kameletbinding\n"
+                    + "spec: {}\n"
+                    + "storage: true\n"
+                    + "version: v1alpha1\n";
     private KameletBindingDeploymentGeneratorService parser;
 
     @Inject
@@ -25,14 +42,13 @@ class KameletBindingDeploymentGeneratorServiceTest {
     @Test
     void parse() {
         List<Step> steps = new ArrayList();
-        Assertions.assertEquals("", parser.parse("", steps));
+        Assertions.assertEquals(EMPTY_INTEGRATION, parser.parse("", steps));
         steps.add(new Step());
-        Assertions.assertEquals("", parser.parse("", steps));
         steps.add(new Step());
-        Assertions.assertEquals("", parser.parse("", steps));
         for (Step step : steps) {
             step.setKind("Kamelet");
         }
         Assertions.assertNotEquals("", parser.parse("", steps));
+        Assertions.assertNotEquals(EMPTY_INTEGRATION, parser.parse("", steps));
     }
 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorService.java
@@ -151,8 +151,7 @@ public class KameletBindingDeploymentGeneratorService
 
     @Override
     public boolean appliesTo(final List<Step> steps) {
-        return steps.size() > 1
-                && steps.stream().allMatch(
+        return steps.stream().allMatch(
                 s -> getKinds().stream()
                         .anyMatch(
                                 Predicate.isEqual(s.getKind().toUpperCase())));

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorService.java
@@ -46,7 +46,9 @@ public class KameletBindingDeploymentGeneratorService
         }
 
         KameletBindingSpec spec = new KameletBindingSpec();
-        spec.setSource(createKameletBindingStep(steps.get(0)));
+        if (steps.size() > 0) {
+            spec.setSource(createKameletBindingStep(steps.get(0)));
+        }
 
         for (int i = 1; i < steps.size() - 1; i++) {
             spec.getSteps().add(createKameletBindingStep(steps.get(i)));
@@ -56,8 +58,9 @@ public class KameletBindingDeploymentGeneratorService
             spec.setSteps(null);
         }
 
-        spec.setSink(createKameletBindingStep(steps.get(steps.size() - 1)));
-
+        if (steps.size() > 1) {
+            spec.setSink(createKameletBindingStep(steps.get(steps.size() - 1)));
+        }
         KameletBinding binding = new KameletBinding(name, spec);
 
         Representer representer = new Representer() {

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorService.java
@@ -80,8 +80,7 @@ public class KameletDeploymentGeneratorService
 
     @Override
     public boolean appliesTo(final List<Step> steps) {
-        return steps.size() > 1
-                && steps.stream().allMatch(
+        return steps.stream().allMatch(
                 s -> getKinds().stream()
                         .anyMatch(
                                 Predicate.isEqual(s.getKind().toUpperCase())));

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserService.java
@@ -80,8 +80,10 @@ public class KameletBindingStepParserService
                              final KameletBindingSpec spec) {
         steps.add(processStep(spec.getSource()));
 
-        for (KameletBindingStep intermediateStep : spec.getSteps()) {
-            steps.add(processStep(intermediateStep));
+        if (spec.getSteps() != null) {
+            for (KameletBindingStep intermediateStep : spec.getSteps()) {
+                steps.add(processStep(intermediateStep));
+            }
         }
 
         steps.add(processStep(spec.getSink()));
@@ -90,24 +92,29 @@ public class KameletBindingStepParserService
     private Step processStep(final KameletBindingStep source) {
         Step step = null;
 
-        if (source.getUri() != null) {
-            log.trace("Found uri component.");
-            String uri = source.getUri();
-            step = catalog.getReadOnlyCatalog()
-                    .searchStepByName(uri.substring(0, uri.indexOf(":")));
-            if (step != null) {
-                log.trace("Found step " + step.getName());
-                setValuesOnParameters(step, uri);
-            }
-        } else if (source.getRef() != null) {
-            log.trace("Found ref component.");
-            step = catalog.getReadOnlyCatalog()
-                    .searchStepByName(source.getRef().getName());
+        try {
 
-            if (step != null) {
-                log.trace("Found step " + step.getName());
-                setValuesOnParameters(step, source.getProperties());
+            if (source.getUri() != null) {
+                log.trace("Found uri component.");
+                String uri = source.getUri();
+                step = catalog.getReadOnlyCatalog()
+                        .searchStepByName(uri.substring(0, uri.indexOf(":")));
+                if (step != null) {
+                    log.trace("Found step " + step.getName());
+                    setValuesOnParameters(step, uri);
+                }
+            } else if (source.getRef() != null) {
+                log.trace("Found ref component.");
+                step = catalog.getReadOnlyCatalog()
+                        .searchStepByName(source.getRef().getName());
+
+                if (step != null) {
+                    log.trace("Found step " + step.getName());
+                    setValuesOnParameters(step, source.getProperties());
+                }
             }
+        } catch (Exception e) {
+            log.trace("Can't parse step -> " + e.getMessage());
         }
 
         return step;

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserService.java
@@ -114,7 +114,7 @@ public class KameletBindingStepParserService
                 }
             }
         } catch (Exception e) {
-            log.trace("Can't parse step -> " + e.getMessage());
+            log.warn("Can't parse step -> " + e.getMessage());
         }
 
         return step;

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/Kamelet.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/Kamelet.java
@@ -53,7 +53,9 @@ public final class Kamelet
         //Define the steps
         setSpec(new KameletSpec());
         getSpec().setFlow(new Flow());
-        getSpec().getFlow().setFrom(processStep(steps.get(0), false));
+        if (steps.size() > 0) {
+            getSpec().getFlow().setFrom(processStep(steps.get(0), false));
+        }
         getSpec().getFlow().setSteps(new ArrayList<>());
 
         for (int i = 1; i < steps.size(); i++) {

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorServiceTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
@@ -23,7 +22,27 @@ class KameletDeploymentGeneratorServiceTest {
     @Test
     void parse() {
         List<Step> steps = new ArrayList<Step>();
-        assertEquals("", service.parse("kamelet-test", steps));
+        assertEquals("apiVersion: camel.apache.org/v1alpha1\n"
+                + "group: camel.apache.org\n"
+                + "kind: Kamelet\n"
+                + "metadata:\n"
+                + "  additionalProperties: {}\n"
+                + "  finalizers: []\n"
+                + "  labels:\n"
+                + "    camel.apache.org/kamelet.type: action\n"
+                + "    camel.apache.org/kamelet.icon: ''\n"
+                + "  managedFields: []\n"
+                + "  name: kamelet-test-action\n"
+                + "  ownerReferences: []\n"
+                + "plural: kamelets\n"
+                + "scope: Namespaced\n"
+                + "served: true\n"
+                + "singular: kamelet\n"
+                + "spec:\n"
+                + "  flow:\n"
+                + "    steps: []\n"
+                + "storage: true\n"
+                + "version: v1alpha1\n", service.parse("kamelet-test", steps));
 
         Step step = new Step();
         step.setKind("Camel-Connector");
@@ -119,12 +138,12 @@ class KameletDeploymentGeneratorServiceTest {
     @Test
     void appliesTo() {
         List<Step> steps = new ArrayList<Step>();
-        assertFalse(service.appliesTo(steps));
+        assertTrue(service.appliesTo(steps));
 
         Step step = new Step();
         step.setKind("Camel-Connector");
         steps.add(step);
-        assertFalse(service.appliesTo(steps));
+        assertTrue(service.appliesTo(steps));
 
         step = new Step();
         step.setKind("Camel-Connector");
@@ -141,7 +160,7 @@ class KameletDeploymentGeneratorServiceTest {
         step = new Step();
         step.setKind("Kamelet");
         steps.add(step);
-        assertFalse(service.appliesTo(steps));
+        assertTrue(service.appliesTo(steps));
 
         step = new Step();
         step.setKind("EIP-BRANCH");
@@ -158,7 +177,7 @@ class KameletDeploymentGeneratorServiceTest {
         step = new Step();
         step.setKind("Kamelet");
         steps.add(step);
-        assertFalse(service.appliesTo(steps));
+        assertTrue(service.appliesTo(steps));
 
         step = new Step();
         step.setKind("Kamelet");

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -17,10 +17,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-infinispan-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
When having an empty integration or an integration with only one step, `kamelet-support` threw errors that made the frontend freeze.