### PR TITLE
Move port to 8081 to not conflict with frontend

### DIFF
--- a/.github/workflows/generate-docker-image.yml
+++ b/.github/workflows/generate-docker-image.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: 🤳 Build Native Quarkus
-        run: mvn clean install -Pnative -DskipTests -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:21.3-java17
+        run: mvn clean install -Pnative -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.0-java17
       - name: 🤳 Build Docker Image
         run: cd api && docker build -f src/main/docker/Dockerfile.native -t kaotoio/backend .
       - name: Login to DockerHub
@@ -56,4 +56,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -20,7 +20,7 @@ jobs:
         image: kaotoio/backend
         ports:
         # will assign a random free host port
-          - 8080/tcp
+          - 8081/tcp
 
     steps:
       - name: 🏠 Checkout repository
@@ -34,7 +34,7 @@ jobs:
       - run: sudo apt-get install xdot
       - run: npm run docs
       - run: mv docs/api-reference.html docs/index.html
-      - run: curl http://localhost:${{ job.services.kaoto.ports[8080] }}/q/openapi?type=json > /tmp/openapi.json
+      - run: curl http://localhost:${{ job.services.kaoto.ports[8081] }}/q/openapi?type=json > /tmp/openapi.json
       - run: wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.20/swagger-codegen-cli-3.0.20.jar
       - run: java -jar swagger-codegen-cli-3.0.20.jar generate -i /tmp/openapi.json -l html2 -o docs/api/
       - name: 🚀 deploy

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you want to learn more about Quarkus, please visit its website: https://quark
 There is a nightly dockerized container for the Kaoto backend. 
 You can run it with the following command:
 
-`docker run --rm -d -p 8080:8080 kaotoio/backend`
+`docker run --rm -d -p 8081:8081 kaotoio/backend`
 
 ## Developing Kaoto
 
@@ -62,9 +62,11 @@ Then you can run your application in dev mode that enables live coding using:
 mvn quarkus:dev -pl api
 ```
 
-Your app is now deployed on `localhost:8080` and you can check the swagger API on `http://localhost:8080/q/swagger-ui/`.
+Your app is now deployed on `localhost:8081` and you can check the swagger 
+API on `http://localhost:8081/q/swagger-ui/`.
 
-> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
+> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev 
+> mode only at http://localhost:8081/q/dev/.
 
 ### Packaging and Running
 

--- a/api/src/main/docker/Dockerfile.native
+++ b/api/src/main/docker/Dockerfile.native
@@ -5,9 +5,9 @@ RUN chown 1001 /work \
     && chown 1001:root /work
 COPY --chown=1001:root target/*-runner /work/application
 
-EXPOSE 8080
+EXPOSE 8081
 USER 1001
 
-HEALTHCHECK --interval=3s --start-period=1s CMD curl --fail http://localhost:8080/ || exit 1
+HEALTHCHECK --interval=3s --start-period=1s CMD curl --fail http://localhost:8081/ || exit 1
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -2,15 +2,10 @@ repository:
   step:
     jar:
       - "https://repo1.maven.org/maven2/org/apache/camel/kamelets/camel-kamelets/0.6.0/camel-kamelets-0.6.0.jar"
-    git:
-      -
-        url: "https://github.com/KaotoIO/camel-component-metadata.git"
-        tag: "main"
+      - "https://github.com/KaotoIO/camel-component-metadata/archive/refs/heads/main.zip"
   viewdefinition:
-    git:
-      -
-        url: "https://github.com/KaotoIO/kaoto-viewdefinition-catalog.git"
-        tag: "main"
+    jar:
+      - "https://github.com/KaotoIO/kaoto-viewdefinition-catalog/archive/refs/heads/main.zip"
 
 crd:
   default: "KameletBinding"
@@ -19,6 +14,7 @@ quarkus:
   http:
     test-port: 8083
     cors: true
+    port: 8081
   log:
     category:
       io.kaoto.backend.api:


### PR DESCRIPTION
This *should* fix the docker job because we are no longer using git.

But once https://github.com/smallrye/smallrye-config/pull/714 is in production, we can use git repositories again.

:crossed_fingers: :crossed_fingers: :crossed_fingers: :crossed_fingers: :crossed_fingers: 