### PR TITLE
fix(kamelet): Properties were not properly parsed

### DIFF
--- a/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.kaoto.backend.model.deployment.kamelet.Expression;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
 import io.kaoto.backend.model.deployment.kamelet.Kamelet;
+import io.kaoto.backend.model.deployment.kamelet.KameletDefinition;
 import io.kaoto.backend.model.deployment.kamelet.KameletSpec;
 import io.kaoto.backend.model.deployment.kamelet.Template;
 import io.kaoto.backend.model.deployment.kamelet.step.ChoiceFlowStep;
@@ -22,6 +23,7 @@ import org.jboss.logging.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +47,10 @@ public class KamelPopulator {
         kamelet.setSpec(new KameletSpec());
         kamelet.getSpec().setTemplate(new Template());
         kamelet.getSpec().getTemplate().setFrom(getFlow(steps));
+        if (metadata.containsKey("definition")
+            && metadata.get("definition") instanceof KameletDefinition def) {
+            kamelet.getSpec().setDefinition(def);
+        }
 
         kamelet.setMetadata(new ObjectMeta());
         populateLabels(kamelet, (Map<String, String>) metadata.getOrDefault(
@@ -82,7 +88,7 @@ public class KamelPopulator {
 
     private void populateAnnotations(final Kamelet kamelet,
                                      final Map<String, String> annotations) {
-        kamelet.getMetadata().setAnnotations(new HashMap<>());
+        kamelet.getMetadata().setAnnotations(new LinkedHashMap<>());
         for (Map.Entry<String, String> entry : annotations.entrySet()) {
             kamelet.getMetadata().getAnnotations().put(entry.getKey(),
                     entry.getValue());

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
@@ -25,7 +25,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -88,7 +87,7 @@ public class KameletStepParserService
                     Kamelet.class);
 
             processMetadata(res, kamelet.getMetadata());
-            processSpec(steps, kamelet.getSpec());
+            processSpec(steps, res, kamelet.getSpec());
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException(
                     "Error trying to parse.", e);
@@ -101,6 +100,7 @@ public class KameletStepParserService
     }
 
     private void processSpec(final List<Step> steps,
+                             final ParseResult<Step> res,
                              final KameletSpec spec) {
         if (spec.getTemplate() != null
                 && spec.getTemplate().getFrom() != null) {
@@ -113,6 +113,8 @@ public class KameletStepParserService
                 }
             }
         }
+
+        res.getMetadata().put("definition", spec.getDefinition());
     }
 
     //there must be a more elegant solution
@@ -274,7 +276,7 @@ public class KameletStepParserService
     private void processMetadata(
             final ParseResult<Step> result,
             final ObjectMeta metadata) {
-        result.setMetadata(new HashMap<>());
+        result.setMetadata(new LinkedHashMap<>());
 
         var labels = new LinkedHashMap<String, String>();
         result.getMetadata().put("labels", labels);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/KameletDefinition.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/KameletDefinition.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 /**
  * ```
@@ -45,7 +46,7 @@ public class KameletDefinition implements Serializable {
     private List<String> required;
 
     @JsonProperty("properties")
-    private KameletDefinitionProperty properties;
+    private Map<String, KameletDefinitionProperty> properties;
 
     public String getTitle() {
         return title;
@@ -71,12 +72,22 @@ public class KameletDefinition implements Serializable {
         this.required = required;
     }
 
-    public KameletDefinitionProperty getProperties() {
+    public Map<String, KameletDefinitionProperty> getProperties() {
         return properties;
     }
 
     public void setProperties(
-            final KameletDefinitionProperty properties) {
+            final Map<String, KameletDefinitionProperty> properties) {
         this.properties = properties;
+    }
+
+    @Override
+    public String toString() {
+        return "KameletDefinition{"
+                + "title='" + title + '\''
+                + ", description='" + description + '\''
+                + ", required=" + required
+                + ", properties=" + properties
+                + '}';
     }
 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/KameletDefinitionProperty.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/KameletDefinitionProperty.java
@@ -63,11 +63,11 @@ public class KameletDefinitionProperty  implements Serializable {
         this.type = type;
     }
 
-    public String getDefaultValue() {
+    public String getDefault() {
         return defaultValue;
     }
 
-    public void setDefaultValue(final String defaultValue) {
+    public void setDefault(final String defaultValue) {
         this.defaultValue = defaultValue;
     }
 
@@ -77,5 +77,16 @@ public class KameletDefinitionProperty  implements Serializable {
 
     public void setExample(final String example) {
         this.example = example;
+    }
+
+    @Override
+    public String toString() {
+        return "KameletDefinitionProperty{"
+                + "title='" + title + '\''
+                + ", description='" + description + '\''
+                + ", type='" + type + '\''
+                + ", defaultValue='" + defaultValue + '\''
+                + ", example='" + example + '\''
+                + '}';
     }
 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/KameletSpec.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/KameletSpec.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 
 import java.io.Serializable;
 
-@JsonPropertyOrder({"definition", "types", "template"})
+@JsonPropertyOrder({"definition", "template", "dependencies"})
 @JsonDeserialize(
         using = JsonDeserializer.None.class
 )
@@ -19,9 +19,6 @@ public final class KameletSpec
     @JsonProperty("definition")
     private KameletDefinition definition;
 
-    @JsonProperty("types")
-    private KameletTypes types;
-
     @JsonProperty("template")
     private Template template;
 
@@ -31,14 +28,6 @@ public final class KameletSpec
 
     public void setDefinition(final KameletDefinition definition) {
         this.definition = definition;
-    }
-
-    public KameletTypes getTypes() {
-        return types;
-    }
-
-    public void setTypes(final KameletTypes types) {
-        this.types = types;
     }
 
     public Template getTemplate() {

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
@@ -2,6 +2,8 @@ package io.kaoto.backend.api.service.step.parser.kamelet;
 
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletDeploymentGeneratorService;
+import io.kaoto.backend.model.deployment.kamelet.KameletDefinition;
+import io.kaoto.backend.model.deployment.kamelet.KameletDefinitionProperty;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -95,6 +97,23 @@ class KameletStepParserServiceTest {
 
         final var dropboxStep = parsed.getSteps().get(2);
         assertEquals("dropbox", dropboxStep.getId());
+
+        KameletDefinition definition =
+                (KameletDefinition) parsed.getMetadata().get("definition");
+
+        assertNotNull(definition);
+
+        assertEquals("Dropbox Sink", definition.getTitle());
+        assertNotNull(definition.getProperties());
+        assertFalse(definition.getProperties().isEmpty());
+        assertEquals(4, definition.getProperties().size());
+        assertTrue(definition.getProperties().containsKey("accessToken"));
+        KameletDefinitionProperty accessToken =
+                definition.getProperties().get("accessToken");
+        assertEquals("Dropbox Access Token", accessToken.getTitle());
+        assertEquals("The access Token to use to access Dropbox",
+                accessToken.getDescription());
+        assertEquals("string", accessToken.getType());
     }
 
     @Test
@@ -104,7 +123,14 @@ class KameletStepParserServiceTest {
                 parsed.getMetadata());
         var parsed2 = service.deepParse(output);
         assertEquals(parsed.getSteps(), parsed2.getSteps());
-        assertEquals(parsed.getMetadata(), parsed2.getMetadata());
+        assertEquals(parsed.getMetadata().keySet(),
+                parsed2.getMetadata().keySet());
+        for (String key : new String[]{"labels", "annotations",
+                "additionalProperties",
+                "name"}) {
+            assertEquals(parsed.getMetadata().get(key),
+                    parsed2.getMetadata().get(key));
+        }
 
         var parsedInc = service.deepParse(bindingIncomplete);
         String outputInc = deploymentService.parse(parsedInc.getSteps(),


### PR DESCRIPTION
The parameters were not properly parsed. As in:

```spec:
  definition:
    properties:
      accessToken:
        title: Dropbox Access Token
        description: The access Token to use to access Dropbox
        type: string
        format: password
        x-descriptors:
          - urn:alm:descriptor:com.tectonic.ui:password
          - urn:camel:group:credentials
```
          
Now `definition` is added to the response sent to the frontend.