### PR TITLE
feature(api): Cluster endpoint throws http errors

### DIFF
--- a/api/src/main/java/io/kaoto/backend/api/resource/v0/IntegrationResource.java
+++ b/api/src/main/java/io/kaoto/backend/api/resource/v0/IntegrationResource.java
@@ -132,11 +132,8 @@ public class IntegrationResource {
                     + "we want the integration to run.")
             @QueryParam("namespace") String namespace) {
         final var crd = customResourceDefinition(request, type, dsl);
-
-        if (clusterService.start(crd, namespace)) {
-            return crd;
-        }
-        return "Error deploying " + request.getName();
+        clusterService.start(crd, namespace);
+        return crd;
     }
 
     @GET

--- a/api/src/main/java/io/kaoto/backend/api/resource/v1/DeploymentsResource.java
+++ b/api/src/main/java/io/kaoto/backend/api/resource/v1/DeploymentsResource.java
@@ -99,11 +99,8 @@ public class DeploymentsResource {
             @QueryParam("namespace") String namespace) {
 
         String securedcrd = securityCheck(crd);
-
-        if (clusterService.start(securedcrd, namespace)) {
-            return securedcrd;
-        }
-        return "Error deploying " + name;
+        clusterService.start(securedcrd, namespace);
+        return securedcrd;
     }
 
     private String securityCheck(final String crd) {

--- a/cluster/src/test/java/io/kaoto/backend/deployment/ClusterServiceTest.java
+++ b/cluster/src/test/java/io/kaoto/backend/deployment/ClusterServiceTest.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -32,10 +33,12 @@ class ClusterServiceTest {
         String ns = "default";
         assertTrue(clusterService.getIntegrations(ns).isEmpty());
 
-        assertFalse(clusterService.start("Wrong text", ns));
+        assertThrows(IllegalArgumentException.class,
+                () -> clusterService.start("Wrong text", ns));
+
         assertTrue(clusterService.getIntegrations(ns).isEmpty());
 
-        assertTrue(clusterService.start(binding, ns));
+        clusterService.start(binding, ns);
         assertFalse(clusterService.getIntegrations(ns).isEmpty());
 
         final var integrations = clusterService.getIntegrations(ns);


### PR DESCRIPTION
Also, enforce lowercase on the crd name as explained in:

```
 io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://127.0.0.1:32953/apis/camel.apache.org/v1alpha1/namespaces/default/kameletbindings. Message: KameletBinding.camel.apache.org "Integration" is invalid: metadata.name: Invalid value: "Integration": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'). Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=metadata.name, message=Invalid value: "Integration": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), reason=FieldValueInvalid, additionalProperties={})], group=camel.apache.org, kind=KameletBinding, name=Integration, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=KameletBinding.camel.apache.org "Integration" is invalid: metadata.name: Invalid value: "Integration": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Invalid, status=Failure, additionalProperties={}).

```