### PR TITLE
Better CR generation

### DIFF
--- a/api/src/test/java/io/kaoto/backend/api/service/deployment/DeploymentServiceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/service/deployment/DeploymentServiceTest.java
@@ -174,25 +174,17 @@ class DeploymentServiceTest {
                 steps.toArray(new Step[0]));
 
         String expectedStr = "apiVersion: camel.apache.org/v1alpha1\n"
-                + "group: camel.apache.org\n"
                 + "kind: KameletBinding\n"
                 + "metadata:\n"
                 + "  additionalProperties: {}\n"
-                + "  finalizers: []\n"
-                + "  managedFields: []\n"
+                + "  annotations: null\n"
+                + "  labels: null\n"
                 + "  name: camel-conector-example\n"
-                + "  ownerReferences: []\n"
-                + "plural: kameletbindings\n"
-                + "scope: Namespaced\n"
-                + "served: true\n"
-                + "singular: kameletbinding\n"
                 + "spec:\n"
                 + "  steps:\n"
                 + "  - uri: log:debug?showBody=true&\n"
                 + "  sink:\n"
-                + "    uri: log:info?showBody=false&\n"
-                + "storage: true\n"
-                + "version: v1alpha1";
+                + "    uri: log:info?showBody=false&";
 
         Assertions.assertFalse(res.isEmpty());
         String result = null;

--- a/api/src/test/java/io/kaoto/backend/api/service/deployment/generator/KameletBindingDeploymentGeneratorServiceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/service/deployment/generator/KameletBindingDeploymentGeneratorServiceTest.java
@@ -17,21 +17,13 @@ class KameletBindingDeploymentGeneratorServiceTest {
 
     public static final String EMPTY_INTEGRATION =
             "apiVersion: camel.apache.org/v1alpha1\n"
-                    + "group: camel.apache.org\n"
                     + "kind: KameletBinding\n"
                     + "metadata:\n"
                     + "  additionalProperties: {}\n"
-                    + "  finalizers: []\n"
-                    + "  managedFields: []\n"
+                    + "  annotations: null\n"
+                    + "  labels: null\n"
                     + "  name: ''\n"
-                    + "  ownerReferences: []\n"
-                    + "plural: kameletbindings\n"
-                    + "scope: Namespaced\n"
-                    + "served: true\n"
-                    + "singular: kameletbinding\n"
-                    + "spec: {}\n"
-                    + "storage: true\n"
-                    + "version: v1alpha1\n";
+                    + "spec: {}\n";
     private KameletBindingDeploymentGeneratorService parser;
 
     @Inject

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletRepresenter.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletRepresenter.java
@@ -1,9 +1,14 @@
 package io.kaoto.backend.api.service.deployment.generator.kamelet;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
 import io.kaoto.backend.model.deployment.kamelet.Expression;
 import io.kaoto.backend.model.deployment.kamelet.KameletBindingSpec;
 import io.kaoto.backend.model.deployment.kamelet.KameletBindingStep;
 import io.kaoto.backend.model.deployment.kamelet.KameletBindingStepRef;
+import io.kaoto.backend.model.deployment.kamelet.KameletDefinition;
+import io.kaoto.backend.model.deployment.kamelet.KameletSpec;
+import io.kaoto.backend.model.deployment.kamelet.Template;
 import io.kaoto.backend.model.deployment.kamelet.step.ChoiceFlowStep;
 import io.kaoto.backend.model.deployment.kamelet.step.From;
 import io.kaoto.backend.model.deployment.kamelet.step.SetBodyFlowStep;
@@ -33,7 +38,9 @@ public class KameletRepresenter extends Representer {
 
     public KameletRepresenter() {
         getPropertyUtils().setSkipMissingProperties(true);
-        getPropertyUtils().setAllowReadOnlyProperties(true);
+
+        customResource();
+        metadata();
 
         //proper order sink steps and source
         spec();
@@ -47,6 +54,49 @@ public class KameletRepresenter extends Representer {
         setBody();
         setHeader();
         expression();
+
+
+    }
+
+    private void customResource() {
+        this.multiRepresenters.put(CustomResource.class,
+                new RepresentMap() {
+                    @Override
+                    public Node representData(final Object data) {
+                        Map<String, Object> properties = new LinkedHashMap<>();
+                        CustomResource cr = (CustomResource) data;
+                        properties.put("apiVersion", cr.getApiVersion());
+                        properties.put("kind", cr.getKind());
+                        properties.put("metadata", cr.getMetadata());
+                        properties.put("spec", cr.getSpec());
+                        return representMapping(getTag(data.getClass(),
+                                        Tag.MAP),
+                                properties,
+                                DumperOptions.FlowStyle.AUTO);
+                    }
+                });
+    }
+
+    private void metadata() {
+        this.multiRepresenters.put(ObjectMeta.class,
+                new RepresentMap() {
+                    @Override
+                    public Node representData(final Object data) {
+                        Map<String, Object> properties = new LinkedHashMap<>();
+                        ObjectMeta meta = (ObjectMeta) data;
+                        if (meta.getAdditionalProperties() != null) {
+                            properties.put("additionalProperties",
+                                    meta.getAdditionalProperties());
+                        }
+                        properties.put("annotations", meta.getAnnotations());
+                        properties.put("labels", meta.getLabels());
+                        properties.put("name", meta.getName());
+                        return representMapping(getTag(data.getClass(),
+                                        Tag.MAP),
+                                properties,
+                                DumperOptions.FlowStyle.BLOCK);
+                    }
+                });
     }
 
     private void spec() {
@@ -72,6 +122,58 @@ public class KameletRepresenter extends Representer {
                 }
             });
 
+        this.multiRepresenters.put(KameletSpec.class,
+                new RepresentMap() {
+                    @Override
+                    public Node representData(final Object data) {
+                        Map<String, Object> properties = new LinkedHashMap<>();
+                        KameletSpec spec = (KameletSpec) data;
+                        properties.put("definition", spec.getDefinition());
+                        properties.put("dependencies", spec.getDependencies());
+                        properties.put("template", spec.getTemplate());
+                        return representMapping(getTag(data.getClass(),
+                                        Tag.MAP),
+                                properties,
+                                DumperOptions.FlowStyle.BLOCK);
+                    }
+                });
+
+        this.multiRepresenters.put(KameletDefinition.class,
+                new RepresentMap() {
+                    @Override
+                    public Node representData(final Object data) {
+                        Map<String, Object> properties = new LinkedHashMap<>();
+                        KameletDefinition def = (KameletDefinition) data;
+                        properties.put("title", def.getTitle());
+                        properties.put("description", def.getDescription());
+                        if (def.getRequired() != null) {
+                            properties.put("required", def.getRequired());
+                        }
+                        if (def.getProperties() != null) {
+                            properties.put("properties", def.getProperties());
+                        }
+                        return representMapping(getTag(data.getClass(),
+                                        Tag.MAP),
+                                properties,
+                                DumperOptions.FlowStyle.BLOCK);
+                    }
+                });
+        this.multiRepresenters.put(Template.class,
+                new RepresentMap() {
+                    @Override
+                    public Node representData(final Object data) {
+                        Map<String, Object> properties = new LinkedHashMap<>();
+                        Template template = (Template) data;
+                        if (template.getBeans() != null) {
+                            properties.put("beans", template.getBeans());
+                        }
+                        properties.put("from", template.getFrom());
+                        return representMapping(getTag(data.getClass(),
+                                        Tag.MAP),
+                                properties,
+                                DumperOptions.FlowStyle.BLOCK);
+                    }
+                });
         this.multiRepresenters.put(KameletBindingStep.class,
             new RepresentMap() {
                 @Override

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorServiceTest.java
@@ -38,21 +38,13 @@ class KameletBindingDeploymentGeneratorServiceTest {
         String name = "kamelet-binding-test";
         md.put("name", name);
         assertEquals("apiVersion: camel.apache.org/v1alpha1\n"
-                + "group: camel.apache.org\n"
                 + "kind: KameletBinding\n"
                 + "metadata:\n"
                 + "  additionalProperties: {}\n"
-                + "  finalizers: []\n"
-                + "  managedFields: []\n"
+                + "  annotations: null\n"
+                + "  labels: null\n"
                 + "  name: " + name + "\n"
-                + "  ownerReferences: []\n"
-                + "plural: kameletbindings\n"
-                + "scope: Namespaced\n"
-                + "served: true\n"
-                + "singular: kameletbinding\n"
-                + "spec: {}\n"
-                + "storage: true\n"
-                + "version: v1alpha1\n",
+                + "spec: {}\n",
                 service.parse(steps, md, Collections.emptyList()));
 
 
@@ -62,26 +54,18 @@ class KameletBindingDeploymentGeneratorServiceTest {
         assertTrue(service.appliesTo(steps));
 
         assertEquals("apiVersion: camel.apache.org/v1alpha1\n"
-                + "group: camel.apache.org\n"
                 + "kind: KameletBinding\n"
                 + "metadata:\n"
                 + "  additionalProperties: {}\n"
-                + "  finalizers: []\n"
-                + "  managedFields: []\n"
+                + "  annotations: null\n"
+                + "  labels: null\n"
                 + "  name: " + name + "\n"
-                + "  ownerReferences: []\n"
-                + "plural: kameletbindings\n"
-                + "scope: Namespaced\n"
-                + "served: true\n"
-                + "singular: kameletbinding\n"
                 + "spec:\n"
                 + "  source:\n"
                 + "    ref:\n"
                 + "      apiVersion: camel.apache.org/v1alpha1\n"
                 + "      name: aws-s3-source\n"
-                + "      kind: Kamelet\n"
-                + "storage: true\n"
-                + "version: v1alpha1\n",
+                + "      kind: Kamelet\n",
                 service.parse(steps, md, Collections.emptyList()));
 
         Step step = catalog.getReadOnlyCatalog()
@@ -98,18 +82,12 @@ class KameletBindingDeploymentGeneratorServiceTest {
         assertTrue(service.appliesTo(steps));
 
         assertEquals("apiVersion: camel.apache.org/v1alpha1\n"
-                + "group: camel.apache.org\n"
                 + "kind: KameletBinding\n"
                 + "metadata:\n"
                 + "  additionalProperties: {}\n"
-                + "  finalizers: []\n"
-                + "  managedFields: []\n"
+                + "  annotations: null\n"
+                + "  labels: null\n"
                 + "  name: " + name + "\n"
-                + "  ownerReferences: []\n"
-                + "plural: kameletbindings\n"
-                + "scope: Namespaced\n"
-                + "served: true\n"
-                + "singular: kameletbinding\n"
                 + "spec:\n"
                 + "  source:\n"
                 + "    ref:\n"
@@ -122,9 +100,7 @@ class KameletBindingDeploymentGeneratorServiceTest {
                 + "      name: broker-name\n"
                 + "      kind: Broker\n"
                 + "    properties:\n"
-                + "      type: example\n"
-                + "storage: true\n"
-                + "version: v1alpha1\n",
+                + "      type: example\n",
                 service.parse(steps, md, Collections.emptyList()));
     }
 

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorServiceTest.java
@@ -28,33 +28,25 @@ class KameletDeploymentGeneratorServiceTest {
         Map<String, Object> md = new HashMap<>();
         md.put("name", "kamelet-test");
         assertEquals("apiVersion: camel.apache.org/v1alpha1\n"
-                + "group: camel.apache.org\n"
                 + "kind: Kamelet\n"
                 + "metadata:\n"
                 + "  additionalProperties: {}\n"
                 + "  annotations:\n"
                 + "    camel.apache.org/kamelet.icon: ''\n"
-                + "  finalizers: []\n"
                 + "  labels:\n"
                 + "    camel.apache.org/kamelet.type: action\n"
-                + "  managedFields: []\n"
                 + "  name: kamelet-test-action\n"
-                + "  ownerReferences: []\n"
-                + "plural: kamelets\n"
-                + "scope: Namespaced\n"
-                + "served: true\n"
-                + "singular: kamelet\n"
                 + "spec:\n"
                 + "  definition:\n"
+                + "    title: null\n"
+                + "    description: null\n"
                 + "    properties: {}\n"
                 + "  dependencies:\n"
                 + "  - camel:core\n"
                 + "  template:\n"
                 + "    from:\n"
                 + "      uri: null\n"
-                + "      steps: []\n"
-                + "storage: true\n"
-                + "version: v1alpha1\n",
+                + "      steps: []\n",
                 service.parse(steps, md, Collections.emptyList()));
 
         Step step = new Step();
@@ -77,24 +69,18 @@ class KameletDeploymentGeneratorServiceTest {
         assertTrue(service.appliesTo(steps));
 
         assertEquals("apiVersion: camel.apache.org/v1alpha1\n"
-                + "group: camel.apache.org\n"
                 + "kind: Kamelet\n"
                 + "metadata:\n"
                 + "  additionalProperties: {}\n"
                 + "  annotations:\n"
                 + "    camel.apache.org/kamelet.icon: ''\n"
-                + "  finalizers: []\n"
                 + "  labels:\n"
                 + "    camel.apache.org/kamelet.type: source\n"
-                + "  managedFields: []\n"
                 + "  name: kamelet-test-source\n"
-                + "  ownerReferences: []\n"
-                + "plural: kamelets\n"
-                + "scope: Namespaced\n"
-                + "served: true\n"
-                + "singular: kamelet\n"
                 + "spec:\n"
                 + "  definition:\n"
+                + "    title: null\n"
+                + "    description: null\n"
                 + "    properties: {}\n"
                 + "  dependencies:\n"
                 + "  - camel:core\n"
@@ -105,9 +91,7 @@ class KameletDeploymentGeneratorServiceTest {
                 + "        level: info\n"
                 + "      steps:\n"
                 + "      - to:\n"
-                + "          uri: kamelet:sink\n"
-                + "storage: true\n"
-                + "version: v1alpha1\n",
+                + "          uri: kamelet:sink\n",
                 service.parse(steps, md, Collections.emptyList()));
 
         step = new Step();
@@ -121,24 +105,18 @@ class KameletDeploymentGeneratorServiceTest {
         assertTrue(service.appliesTo(steps));
 
         assertEquals("apiVersion: camel.apache.org/v1alpha1\n"
-                + "group: camel.apache.org\n"
                 + "kind: Kamelet\n"
                 + "metadata:\n"
                 + "  additionalProperties: {}\n"
                 + "  annotations:\n"
                 + "    camel.apache.org/kamelet.icon: ''\n"
-                + "  finalizers: []\n"
                 + "  labels:\n"
                 + "    camel.apache.org/kamelet.type: source\n"
-                + "  managedFields: []\n"
                 + "  name: kamelet-test-source\n"
-                + "  ownerReferences: []\n"
-                + "plural: kamelets\n"
-                + "scope: Namespaced\n"
-                + "served: true\n"
-                + "singular: kamelet\n"
                 + "spec:\n"
                 + "  definition:\n"
+                + "    title: null\n"
+                + "    description: null\n"
                 + "    properties: {}\n"
                 + "  dependencies:\n"
                 + "  - camel:core\n"
@@ -151,9 +129,7 @@ class KameletDeploymentGeneratorServiceTest {
                 + "      - set-body:\n"
                 + "          constant: Hello Llama\n"
                 + "      - to:\n"
-                + "          uri: kamelet:sink\n"
-                + "storage: true\n"
-                + "version: v1alpha1\n",
+                + "          uri: kamelet:sink\n",
                 service.parse(steps, md, Collections.emptyList()));
     }
 

--- a/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/eip.kamelet.yaml
+++ b/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/eip.kamelet.yaml
@@ -1,5 +1,4 @@
 apiVersion: camel.apache.org/v1alpha1
-group: camel.apache.org
 kind: Kamelet
 metadata:
   additionalProperties: {}
@@ -9,21 +8,14 @@ metadata:
     camel.apache.org/kamelet.icon: whatever
     camel.apache.org/provider: Apache Software Foundation
     camel.apache.org/kamelet.group: Kaoto
-  finalizers: []
   labels:
     camel.apache.org/kamelet.type: action
-  managedFields: []
   name: eip-action
-  ownerReferences: []
-plural: kamelets
-scope: Namespaced
-served: true
-singular: kamelet
 spec:
   definition:
+    title: EIP Kamelet
     description: Used to test all EIP we implement
     properties: {}
-    title: EIP Kamelet
   dependencies:
   - camel:core
   - camel:kamelet
@@ -35,5 +27,3 @@ spec:
           simple: ola ke ase
       - to:
           uri: kamelet:sink
-storage: true
-version: v1alpha1


### PR DESCRIPTION
Be less verbose and omit properties that should not be there when generating the CR. They will be on the cluster, but not for our editor.