### PR TITLE
Temporal fix: Quarkus native mode throws a weird error of constructor

### DIFF
--- a/.github/workflows/generate-docker-image.yml
+++ b/.github/workflows/generate-docker-image.yml
@@ -67,8 +67,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: "api"
-          file: './api/src/main/docker/Dockerfile.native'
-          platforms: linux/amd64,linux/arm64
+          file: './api/src/main/docker/Dockerfile.jvm'
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
not found

Related to #111

It will disable native mode on generated docker images until we understand why it fails.