### PR TITLE
feature(branches): Adding min/max number of branches

### DIFF
--- a/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletFileProcessor.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletFileProcessor.java
@@ -62,11 +62,12 @@ public class KameletFileProcessor extends YamlProcessFile<Step> {
             step.setKind(kind);
 
             if (kamelet.getMetadata() != null) {
-                step.setId(kamelet.getMetadata().getName());
-                step.setName(kamelet.getMetadata().getName());
+                final var metadata = kamelet.getMetadata();
+                step.setId(metadata.getName());
+                step.setName(metadata.getName());
 
-                if (kamelet.getMetadata().getLabels() != null) {
-                    switch (kamelet.getMetadata().getLabels()
+                if (metadata.getLabels() != null) {
+                    switch (metadata.getLabels()
                             .getOrDefault("camel.apache.org/kamelet.type",
                                     "action")
                             .toLowerCase()) {
@@ -76,16 +77,30 @@ public class KameletFileProcessor extends YamlProcessFile<Step> {
                     }
                 }
 
-                if (kamelet.getMetadata().getAnnotations() != null) {
-                    step.setGroup(kamelet.getMetadata().getAnnotations()
+                if (metadata.getAnnotations() != null) {
+                    final var annotations = metadata.getAnnotations();
+                    step.setGroup(annotations
                             .getOrDefault("camel.apache.org/kamelet.group",
                                     "others"));
 
                     step.setIcon(
-                            kamelet.getMetadata().getAnnotations().getOrDefault(
+                            annotations.getOrDefault(
                                     "camel.apache.org/kamelet.icon", ""));
-                }
 
+                    if (annotations.containsKey("kaoto.io/minbranches")) {
+                        step.setMinBranches(
+                                Integer.valueOf(
+                                        annotations
+                                                .get("kaoto.io/minbranches")));
+                    }
+
+                    if (annotations.containsKey("kaoto.io/maxbranches")) {
+                        step.setMaxBranches(
+                                Integer.valueOf(
+                                        annotations
+                                                .get("kaoto.io/maxbranches")));
+                    }
+                }
             }
 
             if (kamelet.getSpec() != null

--- a/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletParseCatalogTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletParseCatalogTest.java
@@ -96,7 +96,7 @@ class KameletParseCatalogTest {
         String name = "dropbox";
         String[] required = new String[]{
                 "operation", "accessToken"};
-        Step step = catalog.searchStepByName(name);
+        final Step step = catalog.searchStepByName(name);
 
         assertEquals(step.getRequired().size(), required.length);
         assertTrue(Arrays.stream(required).allMatch(
@@ -116,6 +116,16 @@ class KameletParseCatalogTest {
             Assertions.assertNotNull(p.getType());
             Assertions.assertNotNull(p.getDescription());
         }
+
+        name = "choice";
+        Step step2 = catalog.searchStepByName(name);
+        Assertions.assertNotNull(step2);
+        assertEquals(name, step2.getId());
+        assertEquals(name, step2.getName());
+        assertEquals("EIP-BRANCH", step2.getKind());
+        assertEquals("MIDDLE", step2.getType());
+        assertEquals(1, step2.getMinBranches());
+        assertEquals(-1, step2.getMaxBranches());
     }
     @Test
     void wrongUrlSilentlyFails() {

--- a/model/src/main/java/io/kaoto/backend/model/step/Step.java
+++ b/model/src/main/java/io/kaoto/backend/model/step/Step.java
@@ -25,6 +25,8 @@ public class Step extends Metadata {
     private List<Parameter> parameters;
     private List<String> required;
     private List<Branch> branches;
+    private Integer minBranches;
+    private Integer maxBranches;
 
     private String uuid;
     private Map<String, Object> metadata;
@@ -35,6 +37,7 @@ public class Step extends Metadata {
         setKind("UNKNOWN");
     }
 
+    //Used only for testing
     public Step(final String identifier, final String connector,
                 final String icon, final List<Parameter> parameters) {
         this();
@@ -169,6 +172,36 @@ public class Step extends Metadata {
 
     public void setBranches(final List<Branch> branches) {
         this.branches = branches;
+    }
+
+
+    /*
+     * 🐱property minBranches: Integer
+     *
+     * Minimum amount of branches used on this step. Zero by default.
+     *
+     */
+    public Integer getMinBranches() {
+        return minBranches;
+    }
+
+    public void setMinBranches(final Integer minBranches) {
+        this.minBranches = minBranches;
+    }
+
+
+    /*
+     * 🐱property maxBranches: Integer
+     *
+     * Maximum amount of branches used on this step. Zero by default.
+     *
+     */
+    public Integer getMaxBranches() {
+        return maxBranches;
+    }
+
+    public void setMaxBranches(final Integer maxBranches) {
+        this.maxBranches = maxBranches;
     }
 
     public void setSpec(final Map<String, Object> spec) {


### PR DESCRIPTION
@kahboom Now steps contain two new properties (`maxBranches` and `minBranches`) to indicate the number of branches that said step supports.

Default is 0.
-1 means unlimited.

![imagen](https://user-images.githubusercontent.com/726590/187891484-d54cb3b1-0f9a-44d9-9ea2-88e852c274b9.png)

