### PR TITLE
Fix tests because no more manual camel conectors

### DIFF
--- a/api/src/test/java/io/kaoto/backend/api/resource/v1/ViewDefinitionResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v1/ViewDefinitionResourceTest.java
@@ -65,7 +65,7 @@ class ViewDefinitionResourceTest {
         steps.add(stepCatalog.getReadOnlyCatalog().searchByID(
                                 "kamelet:source"));
         steps.add(stepCatalog.getReadOnlyCatalog().searchByID(
-                                "log"));
+                                "log-producer"));
 
         final var mapper = new ObjectMapper();
         final var json = mapper.writeValueAsString(steps);

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -4,6 +4,7 @@ repository:
       -
         url: "https://repo1.maven.org/maven2/org/apache/camel/kamelets/camel-kamelets/0.4.0/camel-kamelets-0.4.0.jar"
         if-no-cluster: false
+      - url: "https://github.com/apache/camel/archive/refs/tags/camel-3.18.2.zip"
     git:
       -
         url: "https://github.com/KaotoIO/camel-component-metadata.git"

--- a/camel-route-support/src/test/resources/application.yaml
+++ b/camel-route-support/src/test/resources/application.yaml
@@ -2,6 +2,7 @@ repository:
   step:
     jar:
       - url: "https://repo1.maven.org/maven2/org/apache/camel/kamelets/camel-kamelets/0.4.0/camel-kamelets-0.4.0.jar"
+      - url: "https://github.com/apache/camel/archive/refs/tags/camel-3.18.2.zip"
     git:
       -
         url: "https://github.com/KaotoIO/camel-component-metadata.git"

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserService.java
@@ -151,7 +151,11 @@ public class KameletBindingStepParserService
                                     s.getKind().equalsIgnoreCase(
                                             bindingStep.getRef().getKind()));
                 }
-                step = candidates.findAny();
+                step = candidates
+                        .sorted(Comparator.comparing(
+                                s -> KINDS.indexOf(s.getKind()
+                                        .toUpperCase(Locale.ROOT))))
+                        .findFirst();
 
                 //knative
                 if (step.isPresent()

--- a/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessor.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessor.java
@@ -242,9 +242,9 @@ public class CamelRouteFileProcessor extends JsonProcessFile<Step> {
 
     private String getStepType(final JsonObject component) {
         final boolean isCamelComponentSourceOnly
-                = component.getBoolean("producerOnly");
-        final boolean isCamelComponentSinkOnly
                 = component.getBoolean("consumerOnly");
+        final boolean isCamelComponentSinkOnly
+                = component.getBoolean("producerOnly");
         final boolean canCamelComponentBeSourceAndSink
                 = !isCamelComponentSourceOnly && !isCamelComponentSinkOnly;
 
@@ -273,7 +273,7 @@ public class CamelRouteFileProcessor extends JsonProcessFile<Step> {
 
         Map<String, List<String>> typesToDuplicateTo =
                 Map.of(
-                    SOURCE_TYPE, List.of(SOURCE_TYPE, ACTION_TYPE),
+                    SOURCE_TYPE, List.of(SOURCE_TYPE),
                     ACTION_TYPE, List.of(SOURCE_TYPE, ACTION_TYPE, SINK_TYPE),
                     SINK_TYPE, List.of(ACTION_TYPE, SINK_TYPE)
                 );
@@ -288,8 +288,8 @@ public class CamelRouteFileProcessor extends JsonProcessFile<Step> {
 
         Map<String, String> typeToIdConversion = Map.of(
                 ACTION_TYPE, "action",
-                SINK_TYPE, "consumer",
-                SOURCE_TYPE, "producer"
+                SINK_TYPE, "producer",
+                SOURCE_TYPE, "consumer"
         );
 
         String typedId = step.getId() + "-" + typeToIdConversion.get(type);

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
@@ -101,7 +101,7 @@ class KameletStepParserServiceTest {
         assertEquals(2, choiceStep.getBranches().size());
 
         final var dropboxStep = parsed.getSteps().get(2);
-        assertEquals("dropbox", dropboxStep.getId());
+        assertEquals("dropbox-producer", dropboxStep.getId());
 
         KameletDefinition definition =
                 (KameletDefinition) parsed.getMetadata().get("definition");

--- a/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessorTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessorTest.java
@@ -63,8 +63,8 @@ public class CamelRouteFileProcessorTest {
             final Step parsedStep, final String type) {
         Map<String, String> typeToIdConversion = Map.of(
                 "MIDDLE", "action",
-                "END", "consumer",
-                "START", "producer"
+                "END", "producer",
+                "START", "consumer"
         );
 
         String expectedType = typeToIdConversion.get(type);

--- a/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteParseCatalogTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteParseCatalogTest.java
@@ -44,8 +44,8 @@ public class CamelRouteParseCatalogTest {
 
         assertTrue(catalog.store(steps));
 
-        Step browseComponentSink = catalog.searchByID("browse-consumer");
-        Step browseComponentSource = catalog.searchByID("browse-producer");
+        Step browseComponentSink = catalog.searchByID("browse-producer");
+        Step browseComponentSource = catalog.searchByID("browse-consumer");
         Step browseComponentAction = catalog.searchByID("browse-action");
 
         assertBrowseJsonHasBeenParsedCorrectly(
@@ -93,8 +93,8 @@ public class CamelRouteParseCatalogTest {
             final boolean assertDescription) {
         Map<String, String> typeToIdConversion = Map.of(
                 "MIDDLE", "action",
-                "END", "consumer",
-                "START", "producer"
+                "END", "producer",
+                "START", "consumer"
         );
 
         String expectedType = typeToIdConversion.get(type);

--- a/kamelet-support/src/test/resources/application.yaml
+++ b/kamelet-support/src/test/resources/application.yaml
@@ -2,6 +2,7 @@ repository:
   step:
     jar:
       - url: "https://repo1.maven.org/maven2/org/apache/camel/kamelets/camel-kamelets/0.4.0/camel-kamelets-0.4.0.jar"
+      - url: "https://github.com/apache/camel/archive/refs/tags/camel-3.18.2.zip"
     git:
       -
         url: "https://github.com/KaotoIO/camel-component-metadata.git"


### PR DESCRIPTION
Due to https://github.com/KaotoIO/camel-component-metadata/pull/5 we need to rebuild the tests