### PR TITLE
fix(marshal-eip): Serialization of properties now works

### DIFF
--- a/api/src/test/resources/io/kaoto/backend/api/resource/eip.kamelet.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/eip.kamelet.yaml
@@ -33,7 +33,8 @@ spec:
             - remove-property:
                 name: property
             - marshal:
-                json: {}
+                json:
+                  library: Gson
           - simple: '{{?baz}}'
             steps:
             - transform:

--- a/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
@@ -406,9 +406,11 @@ public class KamelPopulator {
                 marshal.getDataFormat().setFormat(p.getValue().toString());
             } else if ("properties".equalsIgnoreCase(p.getId())) {
                 for (var param : ((ArrayParameter) p).getValue()) {
-                    marshal.getDataFormat().getProperties()
-                            .put(((Map.Entry) param).getKey().toString(),
-                                    ((Map.Entry) param).getValue().toString());
+                    if (param instanceof Object[] array) {
+                        marshal.getDataFormat().getProperties().put(array[0].toString(), array[1].toString());
+                    } else if (param instanceof List list) {
+                        marshal.getDataFormat().getProperties().put(list.get(0).toString(), list.get(1).toString());
+                    }
                 }
             }
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/MarshalFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/MarshalFlowStep.java
@@ -23,7 +23,7 @@ public class MarshalFlowStep implements FlowStep {
     private DataFormat dataFormat;
 
     public MarshalFlowStep() {
-
+        //Needed for the serialization
     }
     @Override
     public Map<String, Object> getRepresenterProperties() {
@@ -45,8 +45,12 @@ public class MarshalFlowStep implements FlowStep {
                 param.setValue(this.getDataFormat().getFormat());
             } else if ("properties".equalsIgnoreCase(param.getId())
                             && this.getDataFormat().getProperties() != null) {
-                param.setValue(this.getDataFormat()
-                        .getProperties().entrySet().toArray());
+                Object[] array = new Object[this.getDataFormat().getProperties().size()];
+                int i = 0;
+                for (var entry : this.getDataFormat().getProperties().entrySet()) {
+                    array[i++] = new Object[]{entry.getKey(), entry.getValue()};
+                }
+                param.setValue(array);
             }
         }
 


### PR DESCRIPTION
Make arrays more "arrayable". 

The serialization to JSON became crazy when using generic `Object[ ]`