### PR TITLE
chore: Enclosing JVM parameter for mutation classlimit to launch

### DIFF
--- a/.github/workflows/mutations.yml
+++ b/.github/workflows/mutations.yml
@@ -27,7 +27,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: 🦾 Build and analyze
-        run: mvn install org.pitest:pitest-maven:mutationCoverage -Pmutations -Dfeatures=+CLASSLIMIT(limit[4])
+        run: mvn install org.pitest:pitest-maven:mutationCoverage -Pmutations -Dfeatures="+CLASSLIMIT(limit[4])"
       - name: 💾 Save results
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
successfully with bash

fixes #261

error was:

```
Run mvn install org.pitest:pitest-maven:mutationCoverage -Pmutations -Dfeatures=+CLASSLIMIT(limit[4])
  mvn install org.pitest:pitest-maven:mutationCoverage -Pmutations -Dfeatures=+CLASSLIMIT(limit[4])
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/17.0.4-101/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Adopt_jdk/17.0.4-101/x64
/home/runner/work/_temp/4db18cf8-ae81-4b0b-8660-f5f4466bcc8b.sh: line 1: syntax error near unexpected token `('
```