### PR TITLE
fix the regression with not beign able to browse for kamelets clusterwide

### DIFF
--- a/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletParseCatalog.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletParseCatalog.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 public final class KameletParseCatalog implements StepCatalogParser {
 
     @ConfigProperty(name = "kaoto.openshift.catalog-namespace",
-            defaultValue = "default")
+            defaultValue = "false")
     private String namespace;
     @Inject
     public void setService(final KameletStepParserService service) {

--- a/metadata/src/main/java/io/kaoto/backend/metadata/parser/ClusterParseCatalog.java
+++ b/metadata/src/main/java/io/kaoto/backend/metadata/parser/ClusterParseCatalog.java
@@ -47,7 +47,6 @@ public class ClusterParseCatalog<T extends Metadata>
     private KubernetesClient kubernetesClient;
 
     public void setKubernetesClient(final KubernetesClient kubernetesClient) {
-        log.error(kubernetesClient);
         this.kubernetesClient = kubernetesClient;
     }
     private ProcessFile<T> yamlProcessFile;
@@ -80,7 +79,7 @@ public class ClusterParseCatalog<T extends Metadata>
             final List<?extends CustomResource> resources;
 
             //if the backend is deployed cluster-wide
-            if ("".equals(namespace)) {
+            if ( "false".equals(namespace) || "".equals(namespace)) {
                  resources = kubernetesClient.resources(cr)
                                 .inAnyNamespace()
                                 .list().getItems();


### PR DESCRIPTION
I changed the value of the new property from "default" to "false". It looks like quarkus doesn't like passing empty ENV variables so instead of fetching all namespaces only default was used. 