### PR TITLE
303 support windows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -49,6 +49,7 @@ jobs:
         include:
           - os: ubuntu-latest
           - os: macos-latest
+          - os: windows-latest
     steps:
       - name: 🗄️ Checkout Source Code
         uses: actions/checkout@v3
@@ -78,6 +79,7 @@ jobs:
         include:
           - os: ubuntu-latest
           - os: macos-latest
+          - os: windows-latest
     steps:
       - name: 🗄️ Checkout Source Code
         uses: actions/checkout@v3

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>quarkus-test-kubernetes-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceTest.java
@@ -1,6 +1,27 @@
 package io.kaoto.backend.api.resource.v1;
 
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.resource.v1.model.Integration;
 import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresenter;
@@ -8,27 +29,6 @@ import io.kaoto.backend.api.service.language.LanguageService;
 import io.kaoto.backend.model.deployment.kamelet.KameletBinding;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import static io.restassured.RestAssured.given;
-import static org.junit.Assert.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @TestHTTPEndpoint(IntegrationsResource.class)
@@ -162,6 +162,6 @@ class IntegrationsResourceTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode());
 
-        assertEquals(yaml, res.extract().body().asString());
+        assertThat(res.extract().body().asString()).isEqualToNormalizingNewlines(yaml);
     }
 }

--- a/camel-route-support/pom.xml
+++ b/camel-route-support/pom.xml
@@ -31,5 +31,10 @@
             <artifactId>quarkus-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+            <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
+++ b/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
@@ -1,19 +1,21 @@
 package io.kaoto.backend.api.service.step.parser.camelroute;
 
-import io.kaoto.backend.api.metadata.catalog.StepCatalog;
-import io.kaoto.backend.api.service.deployment.generator.camelroute.CamelRouteDeploymentGeneratorService;
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kaoto.backend.api.metadata.catalog.StepCatalog;
+import io.kaoto.backend.api.service.deployment.generator.camelroute.CamelRouteDeploymentGeneratorService;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class CamelRouteStepParserServiceTest {
@@ -57,7 +59,7 @@ class CamelRouteStepParserServiceTest {
 
         var yaml = camelRouteDeploymentGeneratorService.parse(steps.getSteps(), steps.getMetadata(),
                 steps.getParameters());
-        assertEquals(route, yaml);
+        assertThat(yaml).isEqualToNormalizingNewlines(route);
         assertTrue(camelRouteDeploymentGeneratorService.supportedCustomResources().isEmpty());
     }
 }

--- a/kamelet-support/pom.xml
+++ b/kamelet-support/pom.xml
@@ -47,5 +47,10 @@
             <artifactId>quarkus-test-kubernetes-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
@@ -255,10 +255,10 @@ public class KameletStepParserService
     public boolean appliesTo(final String yaml) {
         String[] kinds = new String[]{"Kamelet", "Knative", "Camel-Connector", "EIP", "EIP-BRANCH"};
 
-        Pattern pattern = Pattern.compile("(\nkind:)(.+)\n", Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile("[\n|\r]kind:(.+)[\n|\r]", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(yaml);
         if (matcher.find()) {
-            return Arrays.stream(kinds).anyMatch(k -> k.equalsIgnoreCase(matcher.group(2).trim()));
+            return Arrays.stream(kinds).anyMatch(k -> k.equalsIgnoreCase(matcher.group(1).trim()));
         }
 
         return false;

--- a/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletFileProcessor.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletFileProcessor.java
@@ -106,10 +106,10 @@ public class KameletFileProcessor extends YamlProcessFile<Step> {
 
     private String getKind(final String yaml) {
         Pattern pattern = Pattern.compile(
-                "(\nkind:)(.+)\n", Pattern.CASE_INSENSITIVE);
+                "[\n|\r]kind:(.+)[\n|\r]", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(yaml);
         if (matcher.find()) {
-            return matcher.group(2).trim();
+            return matcher.group(1).trim();
         } else {
             return null;
         }

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletBindingStepParserServiceTest.java
@@ -9,6 +9,7 @@ import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletBindingD
 import io.kaoto.backend.model.deployment.kamelet.KameletBinding;
 import io.kaoto.backend.model.step.Step;
 import io.quarkus.test.junit.QuarkusTest;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -71,7 +73,7 @@ class KameletBindingStepParserServiceTest {
         assertTrue(parsed.getParameters().isEmpty());
         var yaml = deploymentService.parse(parsed.getSteps(), parsed.getMetadata(), parsed.getParameters());
 
-        assertEquals(binding, yaml);
+        assertThat(yaml).isEqualToNormalizingNewlines(binding);
     }
 
     @Test
@@ -84,7 +86,7 @@ class KameletBindingStepParserServiceTest {
         assertEquals(2, parsed.getSteps().size());
        var yaml = deploymentService.parse(parsed.getSteps(), parsed.getMetadata(), parsed.getParameters());
 
-        assertEquals(binding, yaml);
+       assertThat(yaml).isEqualToNormalizingNewlines(binding);
     }
 
     @Test

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -187,9 +188,8 @@ class KameletStepParserServiceTest {
         final var parsed = service.deepParse(kameletEIP);
         assertNotNull(parsed);
         assertTrue(deploymentService.appliesTo(parsed.getSteps()));
-        assertEquals(kameletEIP, deploymentService.parse(parsed.getSteps(), parsed.getMetadata(),
-                parsed.getParameters()));
-
+        String parsedString = deploymentService.parse(parsed.getSteps(), parsed.getMetadata(), parsed.getParameters());
+        assertThat(parsedString).isEqualToNormalizingNewlines(kameletEIP);
     }
 
     @Test

--- a/metadata/src/main/java/io/kaoto/backend/metadata/parser/JarParseCatalog.java
+++ b/metadata/src/main/java/io/kaoto/backend/metadata/parser/JarParseCatalog.java
@@ -5,7 +5,6 @@ import io.kaoto.backend.model.Metadata;
 import org.apache.commons.io.IOUtils;
 import org.jboss.logging.Logger;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -81,7 +80,7 @@ public class JarParseCatalog<T extends Metadata>
                                       final List<CompletableFuture<Void>> futureMd, final List<T> metadataList)
             throws IOException {
         long size = zipEntry.getSize();
-        if (!zipEntry.getName().endsWith(File.separator) && this.processFile.isDesiredType(zipEntry.getName())) {
+        if (!zipEntry.isDirectory() && this.processFile.isDesiredType(zipEntry.getName())) {
             final InputStreamReader isr = new InputStreamReader(zis);
             final String content = IOUtils.toString(isr);
             size = content.length();

--- a/metadata/src/main/java/io/kaoto/backend/metadata/parser/view/ViewDefinitionParseCatalog.java
+++ b/metadata/src/main/java/io/kaoto/backend/metadata/parser/view/ViewDefinitionParseCatalog.java
@@ -74,10 +74,10 @@ class ViewDefinitionProcessFile extends YamlProcessFile<ViewDefinition> {
     private boolean appliesTo(final String yaml) {
         String[] kinds = new String[]{"generic", "step"};
 
-        Pattern pattern = Pattern.compile("(\ntype:)(.+)\n", Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile("[\r|\n]type:(.+)[\n|\r]", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(yaml);
         if (matcher.find()) {
-            return Arrays.stream(kinds).anyMatch(k -> k.equalsIgnoreCase(matcher.group(2).trim()));
+            return Arrays.stream(kinds).anyMatch(k -> k.equalsIgnoreCase(matcher.group(1).trim()));
         }
 
         return false;


### PR DESCRIPTION
~based on https://github.com/KaotoIO/kaoto-backend/pull/308 (better to review and merge the other before reviewing this one)~ done and rebased

There was different types of issues:
* impacting Runtime:
  * to set the Read, Write and Executable rights for the owner of the file: for Linux and Mac, we can/should use the Posix notation. For windows we need to use the setReadable, setWriteable and setExecutable methods
  * When reading Zip entries, to determine if it is a folder or not, we cannot use  the File.separator because the zip entry name is always a forwardslash, it is independent from the OS.
  * when using a Pattern for end of line, cannot use only `\n`, it needs to use \r or \n. In theory, we should be able to use `^` and `$` but I wasn't able to make it working with it
* impacting test only:
  *  when comparing String coming from files and from yaml parser, we need to ignore OS different types of newlines. AssertJ is providing a convenient method to deal with that.

fixes #303
fixes #306 