### PR TITLE
Improve native GitHub workflow

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -69,6 +69,19 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: 🤳 Run native tests
         run: mvn install -Pnative
+      - name: Archive Quarkus log for native tests
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: quarkus-logs-${{ matrix.os }}
+          path: '**/target/quarkus.log'
+      - name: Archive native binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: kaoto-runner-${{ matrix.os }}
+          path: |
+            api/target/*-runner
+            api\target\*-runner.exe
 
   jvm-tests:
     name: 👩🏼‍🏭 JVM tests for ${{ matrix.os }} 👩🏼‍🏭


### PR DESCRIPTION
- store native binaries, it allows to download and test manually if needed; Especially useful for Windows as building it requires a complex setup
- store the quarkus.log in case of failures, it allows to have more information when Integration tests are failing