### PR TITLE
WIP: Add validation schema support

### DIFF
--- a/api/src/main/java/io/kaoto/backend/api/resource/v1/CapabilitiesResource.java
+++ b/api/src/main/java/io/kaoto/backend/api/resource/v1/CapabilitiesResource.java
@@ -4,6 +4,7 @@ import io.kaoto.backend.api.resource.v1.model.Capabilities;
 import io.kaoto.backend.api.service.language.LanguageService;
 import io.kaoto.backend.deployment.ClusterService;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
@@ -11,6 +12,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -71,6 +73,17 @@ public class CapabilitiesResource {
         return String.format("{\"namespace\": \"%s\"}",
                 clusterService.getDefaultNamespace());
     }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/{dsl}/schema/")
+    @Operation(summary = "Get validation schema for particular dsl",
+            description = "Returns a validation schema of specified DSL if exists. If not empty string is returned.")
+    public String getValidationSchema(
+            @Parameter (description = "Target DSL for the validation schema") @PathParam("dsl") String dsl) {
+        return languageService.getValidationSchema(dsl);
+    }
+
 
     @ServerExceptionMapper
     public Response mapException(final Exception x) {

--- a/api/src/main/java/io/kaoto/backend/api/service/language/LanguageService.java
+++ b/api/src/main/java/io/kaoto/backend/api/service/language/LanguageService.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * 🐱miniclass LanguageService (CapabilitiesResource)
@@ -45,6 +46,9 @@ public class LanguageService {
         Map<String, Map<String, String>> res = new HashMap<>();
 
         for (DeploymentGeneratorService parser : getGeneratorServices()) {
+            String validationSchemaURI = parser.validationSchema()
+                    .equals("")?"":String.format("/v1/capabilities/%s/schema",parser.identifier());
+
             addNewLanguage(res, parser.identifier(), parser.description());
             res.get(parser.identifier())
                     .put("step-kinds", parser.getKinds().toString());
@@ -55,6 +59,8 @@ public class LanguageService {
                             Boolean.toString(
                                     !parser.supportedCustomResources()
                                             .isEmpty()));
+            res.get(parser.identifier())
+                    .put("validationSchema",validationSchemaURI);
         }
 
         for (StepParserService parser : getStepParserServices()) {
@@ -69,6 +75,18 @@ public class LanguageService {
         }
 
         return res.values();
+    }
+
+    public String getValidationSchema(String dsl) {
+        String schema = "";
+
+        Optional<DeploymentGeneratorService> found = getGeneratorServices().stream()
+                .filter( p -> p.identifier().equalsIgnoreCase(dsl))
+                .findFirst();
+        if (found.isPresent()) {
+            schema = found.get().validationSchema();
+        }
+        return  schema;
     }
 
     private String addNewLanguage(final Map<String, Map<String, String>> res,

--- a/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/CamelRouteDeploymentGeneratorService.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/CamelRouteDeploymentGeneratorService.java
@@ -9,12 +9,15 @@ import io.kaoto.backend.model.deployment.camelroute.CamelRoute;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.jboss.logging.Logger;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.nodes.Tag;
 
 import javax.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,6 +36,8 @@ public class CamelRouteDeploymentGeneratorService implements DeploymentGenerator
     private static final List<String> KINDS = Arrays.asList(
             CAMEL_CONNECTOR, EIP, EIP_BRANCHES);
 
+    private Logger log = Logger.getLogger(CamelRouteDeploymentGeneratorService.class);
+
     public CamelRouteDeploymentGeneratorService() {
         //Empty for injection
     }
@@ -48,6 +53,18 @@ public class CamelRouteDeploymentGeneratorService implements DeploymentGenerator
 
     public String description() {
         return "A camel route is a non deployable in cluster workflow of actions and steps.";
+    }
+
+    @Override
+    public String validationSchema() {
+        try {
+            String schema = new String(CamelRouteDeploymentGeneratorService.class
+                    .getResourceAsStream("camel-yaml-dsl.json").readAllBytes());
+            return schema;
+        } catch (IOException e) {
+            log.error("Can't load Camel YAML DSL schema", e);
+        }
+        return  "";
     }
 
     @Override

--- a/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/IntegrationDeploymentGeneratorService.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/IntegrationDeploymentGeneratorService.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -60,6 +61,18 @@ public class IntegrationDeploymentGeneratorService
 
     public String description() {
         return "An Integration defines a workflow of actions and steps.";
+    }
+
+    @Override
+    public String validationSchema() {
+        try {
+            String schema = new String(CamelRouteDeploymentGeneratorService.class
+                    .getResourceAsStream("integration.json").readAllBytes());
+            return schema;
+        } catch (IOException e) {
+            log.error("Can't load Integration DSL schema", e);
+        }
+        return  "";
     }
 
     @Override

--- a/camel-route-support/src/main/resources/io/kaoto/backend/api/service/deployment/generator/camelroute/camel-yaml-dsl.json
+++ b/camel-route-support/src/main/resources/io/kaoto/backend/api/service/deployment/generator/camelroute/camel-yaml-dsl.json
@@ -1,0 +1,7822 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "type" : "array",
+  "items" : {
+    "maxProperties" : 1,
+    "definitions" : {
+      "org.apache.camel.model.ProcessorDefinition" : {
+        "type" : "object",
+        "maxProperties" : 1,
+        "properties" : {
+          "aggregate" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.AggregateDefinition"
+          },
+          "bean" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.BeanDefinition"
+          },
+          "do-catch" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.CatchDefinition"
+          },
+          "doCatch" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.CatchDefinition"
+          },
+          "choice" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ChoiceDefinition"
+          },
+          "circuit-breaker" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.CircuitBreakerDefinition"
+          },
+          "circuitBreaker" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.CircuitBreakerDefinition"
+          },
+          "claim-check" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ClaimCheckDefinition"
+          },
+          "claimCheck" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ClaimCheckDefinition"
+          },
+          "convert-body-to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ConvertBodyDefinition"
+          },
+          "convertBodyTo" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ConvertBodyDefinition"
+          },
+          "delay" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.DelayDefinition"
+          },
+          "dynamic-router" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.DynamicRouterDefinition"
+          },
+          "dynamicRouter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.DynamicRouterDefinition"
+          },
+          "enrich" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.EnrichDefinition"
+          },
+          "filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FilterDefinition"
+          },
+          "do-finally" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FinallyDefinition"
+          },
+          "doFinally" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FinallyDefinition"
+          },
+          "idempotent-consumer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.IdempotentConsumerDefinition"
+          },
+          "idempotentConsumer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.IdempotentConsumerDefinition"
+          },
+          "in-only" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InOnlyDefinition"
+          },
+          "inOnly" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InOnlyDefinition"
+          },
+          "in-out" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InOutDefinition"
+          },
+          "inOut" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InOutDefinition"
+          },
+          "intercept" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptDefinition"
+          },
+          "intercept-from" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptFromDefinition"
+          },
+          "interceptFrom" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptFromDefinition"
+          },
+          "intercept-send-to-endpoint" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptSendToEndpointDefinition"
+          },
+          "interceptSendToEndpoint" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptSendToEndpointDefinition"
+          },
+          "kamelet" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.KameletDefinition"
+          },
+          "load-balance" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LoadBalanceDefinition"
+          },
+          "loadBalance" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LoadBalanceDefinition"
+          },
+          "log" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LogDefinition"
+          },
+          "loop" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LoopDefinition"
+          },
+          "marshal" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.MarshalDefinition"
+          },
+          "multicast" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.MulticastDefinition"
+          },
+          "on-completion" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnCompletionDefinition"
+          },
+          "onCompletion" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnCompletionDefinition"
+          },
+          "on-fallback" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnFallbackDefinition"
+          },
+          "onFallback" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnFallbackDefinition"
+          },
+          "otherwise" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OtherwiseDefinition"
+          },
+          "pausable" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PausableDefinition"
+          },
+          "pipeline" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PipelineDefinition"
+          },
+          "policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PolicyDefinition"
+          },
+          "poll-enrich" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PollEnrichDefinition"
+          },
+          "pollEnrich" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PollEnrichDefinition"
+          },
+          "process" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ProcessDefinition"
+          },
+          "recipient-list" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RecipientListDefinition"
+          },
+          "recipientList" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RecipientListDefinition"
+          },
+          "remove-header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+          },
+          "removeHeader" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+          },
+          "remove-headers" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+          },
+          "removeHeaders" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+          },
+          "remove-properties" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+          },
+          "removeProperties" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+          },
+          "remove-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertyDefinition"
+          },
+          "removeProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertyDefinition"
+          },
+          "resequence" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ResequenceDefinition"
+          },
+          "resumable" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ResumableDefinition"
+          },
+          "rollback" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RollbackDefinition"
+          },
+          "routing-slip" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RoutingSlipDefinition"
+          },
+          "routingSlip" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RoutingSlipDefinition"
+          },
+          "saga" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SagaDefinition"
+          },
+          "sample" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SamplingDefinition"
+          },
+          "script" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ScriptDefinition"
+          },
+          "set-body" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetBodyDefinition"
+          },
+          "setBody" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetBodyDefinition"
+          },
+          "set-exchange-pattern" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetExchangePatternDefinition"
+          },
+          "setExchangePattern" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetExchangePatternDefinition"
+          },
+          "set-header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetHeaderDefinition"
+          },
+          "setHeader" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetHeaderDefinition"
+          },
+          "set-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetPropertyDefinition"
+          },
+          "setProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetPropertyDefinition"
+          },
+          "sort" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SortDefinition"
+          },
+          "split" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SplitDefinition"
+          },
+          "step" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.StepDefinition"
+          },
+          "stop" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.StopDefinition"
+          },
+          "threads" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ThreadsDefinition"
+          },
+          "throttle" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ThrottleDefinition"
+          },
+          "throw-exception" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ThrowExceptionDefinition"
+          },
+          "throwException" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ThrowExceptionDefinition"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "to-d" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDynamicDefinition"
+          },
+          "toD" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDynamicDefinition"
+          },
+          "transacted" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TransactedDefinition"
+          },
+          "transform" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TransformDefinition"
+          },
+          "do-try" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TryDefinition"
+          },
+          "doTry" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TryDefinition"
+          },
+          "unmarshal" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.UnmarshalDefinition"
+          },
+          "validate" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ValidateDefinition"
+          },
+          "when" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+          },
+          "when-skip-send-to-endpoint" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WhenSkipSendToEndpointDefinition"
+          },
+          "whenSkipSendToEndpoint" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WhenSkipSendToEndpointDefinition"
+          },
+          "wire-tap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WireTapDefinition"
+          },
+          "wireTap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WireTapDefinition"
+          },
+          "service-call" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ServiceCallDefinition"
+          },
+          "serviceCall" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ServiceCallDefinition"
+          }
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.BeansDeserializer" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.NamedBeanDefinition"
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer" : {
+        "type" : "object",
+        "properties" : {
+          "dead-letter-channel" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DeadLetterChannelDefinition"
+          },
+          "log" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DefaultErrorHandlerDefinition"
+          },
+          "none" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition"
+          },
+          "ref" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.NamedBeanDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.model.AggregateDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "aggregate-controller" : {
+            "type" : "string"
+          },
+          "aggregation-repository" : {
+            "type" : "string"
+          },
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-allow-null" : {
+            "type" : "boolean"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "close-correlation-key-on-completion" : {
+            "type" : "number"
+          },
+          "complete-all-on-stop" : {
+            "type" : "boolean"
+          },
+          "completion-from-batch-consumer" : {
+            "type" : "boolean"
+          },
+          "completion-interval" : {
+            "type" : "string"
+          },
+          "completion-on-new-correlation-group" : {
+            "type" : "boolean"
+          },
+          "completion-predicate" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "completion-size" : {
+            "type" : "number"
+          },
+          "completion-size-expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "completion-timeout" : {
+            "type" : "string"
+          },
+          "completion-timeout-checker-interval" : {
+            "type" : "string"
+          },
+          "completion-timeout-expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "correlation-expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "discard-on-aggregation-failure" : {
+            "type" : "boolean"
+          },
+          "discard-on-completion-timeout" : {
+            "type" : "boolean"
+          },
+          "eager-check-completion" : {
+            "type" : "boolean"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "force-completion-on-stop" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-invalid-correlation-keys" : {
+            "type" : "boolean"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "optimistic-lock-retry-policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OptimisticLockRetryPolicyDefinition"
+          },
+          "optimistic-locking" : {
+            "type" : "boolean"
+          },
+          "parallel-processing" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "timeout-checker-executor-service" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "aggregation-strategy" ]
+      },
+      "org.apache.camel.model.BeanDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "bean-type" : {
+              "type" : "string"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "method" : {
+              "type" : "string"
+            },
+            "ref" : {
+              "type" : "string"
+            },
+            "scope" : {
+              "type" : "string",
+              "enum" : [ "Singleton", "Request", "Prototype" ]
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.CatchDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "exception" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-when" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.ChoiceDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "otherwise" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OtherwiseDefinition"
+          },
+          "precondition" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "when" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.CircuitBreakerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "configuration" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "fault-tolerance-configuration" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FaultToleranceConfigurationDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-fallback" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnFallbackDefinition"
+          },
+          "resilience4j-configuration" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.Resilience4jConfigurationDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.ClaimCheckDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "filter" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "key" : {
+            "type" : "string"
+          },
+          "operation" : {
+            "type" : "string",
+            "enum" : [ "Get", "GetAndRemove", "Set", "Push", "Pop" ]
+          }
+        },
+        "required" : [ "operation" ]
+      },
+      "org.apache.camel.model.ContextScanDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "excludes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "include-non-singletons" : {
+            "type" : "boolean"
+          },
+          "includes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.ConvertBodyDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "charset" : {
+              "type" : "string"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "mandatory" : {
+              "type" : "boolean"
+            },
+            "type" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "type" ]
+      },
+      "org.apache.camel.model.DataFormatDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.DelayDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "async-delayed" : {
+            "type" : "boolean"
+          },
+          "caller-runs-when-rejected" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.DescriptionDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "lang" : {
+              "type" : "string"
+            },
+            "text" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.DynamicRouterDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "cache-size" : {
+            "type" : "number"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-invalid-endpoints" : {
+            "type" : "boolean"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "uri-delimiter" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.EnrichDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "aggregate-on-exception" : {
+            "type" : "boolean"
+          },
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-allow-null" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "allow-optimised-components" : {
+            "type" : "boolean"
+          },
+          "cache-size" : {
+            "type" : "number"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-invalid-endpoint" : {
+            "type" : "boolean"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "share-unit-of-work" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.ErrorHandlerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "dead-letter-channel" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DeadLetterChannelDefinition"
+          },
+          "default-error-handler" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DefaultErrorHandlerDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "jta-transaction-error-handler" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.JtaTransactionErrorHandlerDefinition"
+          },
+          "no-error-handler" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition"
+          },
+          "spring-transaction-error-handler" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.SpringTransactionErrorHandlerDefinition"
+          }
+        }
+      },
+      "org.apache.camel.model.ExpressionSubElementDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "constant" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+          },
+          "csimple" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.CSimpleExpression"
+          },
+          "datasonnet" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.DatasonnetExpression"
+          },
+          "exchange-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "exchangeProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "groovy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.GroovyExpression"
+          },
+          "header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+          },
+          "hl7terser" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+          },
+          "joor" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JoorExpression"
+          },
+          "jq" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+          },
+          "jsonpath" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+          },
+          "language" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.LanguageExpression"
+          },
+          "method" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.MethodCallExpression"
+          },
+          "mvel" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.MvelExpression"
+          },
+          "ognl" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.OgnlExpression"
+          },
+          "ref" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.RefExpression"
+          },
+          "simple" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+          },
+          "spel" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.SpELExpression"
+          },
+          "tokenize" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.TokenizerExpression"
+          },
+          "xpath" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.XPathExpression"
+          },
+          "xquery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.XQueryExpression"
+          },
+          "xtokenize" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+          }
+        }
+      },
+      "org.apache.camel.model.FaultToleranceConfigurationDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "bulkhead-enabled" : {
+            "type" : "boolean"
+          },
+          "bulkhead-executor-service" : {
+            "type" : "string"
+          },
+          "bulkhead-max-concurrent-calls" : {
+            "type" : "number"
+          },
+          "bulkhead-waiting-task-queue" : {
+            "type" : "number"
+          },
+          "circuit-breaker" : {
+            "type" : "string"
+          },
+          "delay" : {
+            "type" : "string"
+          },
+          "failure-ratio" : {
+            "type" : "number"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "request-volume-threshold" : {
+            "type" : "number"
+          },
+          "success-threshold" : {
+            "type" : "number"
+          },
+          "timeout-duration" : {
+            "type" : "string"
+          },
+          "timeout-enabled" : {
+            "type" : "boolean"
+          },
+          "timeout-pool-size" : {
+            "type" : "number"
+          },
+          "timeout-scheduled-executor-service" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.FilterDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "status-property-name" : {
+            "type" : "string"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.FinallyDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.FromDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.model.GlobalOptionDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key", "value" ]
+      },
+      "org.apache.camel.model.GlobalOptionsDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "global-option" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.GlobalOptionDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.IdempotentConsumerDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "completion-eager" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "eager" : {
+            "type" : "boolean"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "idempotent-repository" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "remove-on-failure" : {
+            "type" : "boolean"
+          },
+          "skip-duplicate" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        },
+        "required" : [ "idempotent-repository" ]
+      },
+      "org.apache.camel.model.InOnlyDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.InOutDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.InputTypeDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "urn" : {
+            "type" : "string"
+          },
+          "validate" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "urn" ]
+      },
+      "org.apache.camel.model.InterceptDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.InterceptFromDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "steps" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+              }
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.InterceptSendToEndpointDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "after-uri" : {
+              "type" : "string"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "skip-send-to-original-endpoint" : {
+              "type" : "string"
+            },
+            "steps" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+              }
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.KameletDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "steps" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+              }
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.LoadBalanceDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "custom-load-balancer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "failover" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "random" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition"
+          },
+          "round-robin" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "sticky" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.StickyLoadBalancerDefinition"
+          },
+          "topic" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition"
+          },
+          "weighted" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition"
+          }
+        }
+      },
+      "org.apache.camel.model.LogDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "log-name" : {
+              "type" : "string"
+            },
+            "logger" : {
+              "type" : "string"
+            },
+            "logging-level" : {
+              "type" : "string",
+              "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+            },
+            "marker" : {
+              "type" : "string"
+            },
+            "message" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "message" ]
+      },
+      "org.apache.camel.model.LoopDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "break-on-shutdown" : {
+            "type" : "boolean"
+          },
+          "copy" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "do-while" : {
+            "type" : "boolean"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.MarshalDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "any23" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Any23DataFormat"
+          },
+          "asn1" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+          },
+          "avro" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+          },
+          "barcode" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+          },
+          "base64" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+          },
+          "bindy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+          },
+          "cbor" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+          },
+          "crypto" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+          },
+          "csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+          },
+          "custom" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "fhir-json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+          },
+          "fhir-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+          },
+          "flatpack" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+          },
+          "grok" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+          },
+          "gzip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+          },
+          "hl7" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+          },
+          "ical" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "jackson-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+          },
+          "jaxb" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+          },
+          "json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+          },
+          "json-api" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+          },
+          "lzf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+          },
+          "mime-multipart" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+          },
+          "pgp" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+          },
+          "protobuf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+          },
+          "rss" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+          },
+          "soap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+          },
+          "syslog" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+          },
+          "tar-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+          },
+          "thrift" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+          },
+          "tidy-markup" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+          },
+          "univocity-csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+          },
+          "univocity-fixed" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+          },
+          "univocity-tsv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+          },
+          "xml-security" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+          },
+          "xstream" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+          },
+          "yaml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+          },
+          "zip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+          },
+          "zip-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+          }
+        }
+      },
+      "org.apache.camel.model.MulticastDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-allow-null" : {
+            "type" : "boolean"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-prepare" : {
+            "type" : "string"
+          },
+          "parallel-aggregate" : {
+            "type" : "boolean"
+          },
+          "parallel-processing" : {
+            "type" : "boolean"
+          },
+          "share-unit-of-work" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "stop-on-exception" : {
+            "type" : "boolean"
+          },
+          "streaming" : {
+            "type" : "boolean"
+          },
+          "timeout" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.OnCompletionDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "mode" : {
+            "type" : "string",
+            "enum" : [ "AfterConsumer", "BeforeConsumer" ]
+          },
+          "on-complete-only" : {
+            "type" : "boolean"
+          },
+          "on-failure-only" : {
+            "type" : "boolean"
+          },
+          "on-when" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+          },
+          "parallel-processing" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "use-original-message" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.OnExceptionDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "continued" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "exception" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "handled" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-exception-occurred-ref" : {
+            "type" : "string"
+          },
+          "on-redelivery-ref" : {
+            "type" : "string"
+          },
+          "on-when" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+          },
+          "redelivery-policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redelivery-policy-ref" : {
+            "type" : "string"
+          },
+          "retry-while" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "use-original-body" : {
+            "type" : "boolean"
+          },
+          "use-original-message" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.OnFallbackDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "fallback-via-network" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.OptimisticLockRetryPolicyDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "exponential-back-off" : {
+            "type" : "boolean"
+          },
+          "maximum-retries" : {
+            "type" : "number"
+          },
+          "maximum-retry-delay" : {
+            "type" : "string"
+          },
+          "random-back-off" : {
+            "type" : "boolean"
+          },
+          "retry-delay" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.OtherwiseDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.OutputDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.OutputTypeDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "urn" : {
+            "type" : "string"
+          },
+          "validate" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "urn" ]
+      },
+      "org.apache.camel.model.PackageScanDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "excludes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "includes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "package" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.PausableDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "consumer-listener" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "until-check" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "consumer-listener", "until-check" ]
+      },
+      "org.apache.camel.model.PipelineDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.PolicyDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        },
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.PollEnrichDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "aggregate-on-exception" : {
+            "type" : "boolean"
+          },
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-allow-null" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "cache-size" : {
+            "type" : "number"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-invalid-endpoint" : {
+            "type" : "boolean"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "timeout" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.ProcessDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "ref" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.PropertyDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key", "value" ]
+      },
+      "org.apache.camel.model.PropertyExpressionDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "key" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.RecipientListDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-allow-null" : {
+            "type" : "boolean"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "cache-size" : {
+            "type" : "number"
+          },
+          "delimiter" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-invalid-endpoints" : {
+            "type" : "boolean"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-prepare" : {
+            "type" : "string"
+          },
+          "parallel-aggregate" : {
+            "type" : "boolean"
+          },
+          "parallel-processing" : {
+            "type" : "boolean"
+          },
+          "share-unit-of-work" : {
+            "type" : "boolean"
+          },
+          "stop-on-exception" : {
+            "type" : "boolean"
+          },
+          "streaming" : {
+            "type" : "boolean"
+          },
+          "timeout" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.RedeliveryPolicyDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "allow-redelivery-while-stopping" : {
+            "type" : "boolean"
+          },
+          "async-delayed-redelivery" : {
+            "type" : "boolean"
+          },
+          "back-off-multiplier" : {
+            "type" : "number"
+          },
+          "collision-avoidance-factor" : {
+            "type" : "number"
+          },
+          "delay-pattern" : {
+            "type" : "string"
+          },
+          "disable-redelivery" : {
+            "type" : "boolean"
+          },
+          "exchange-formatter-ref" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "log-continued" : {
+            "type" : "boolean"
+          },
+          "log-exhausted" : {
+            "type" : "boolean"
+          },
+          "log-exhausted-message-body" : {
+            "type" : "boolean"
+          },
+          "log-exhausted-message-history" : {
+            "type" : "boolean"
+          },
+          "log-handled" : {
+            "type" : "boolean"
+          },
+          "log-new-exception" : {
+            "type" : "boolean"
+          },
+          "log-retry-attempted" : {
+            "type" : "boolean"
+          },
+          "log-retry-stack-trace" : {
+            "type" : "boolean"
+          },
+          "log-stack-trace" : {
+            "type" : "boolean"
+          },
+          "maximum-redeliveries" : {
+            "type" : "number"
+          },
+          "maximum-redelivery-delay" : {
+            "type" : "string"
+          },
+          "redelivery-delay" : {
+            "type" : "string"
+          },
+          "retries-exhausted-log-level" : {
+            "type" : "string"
+          },
+          "retry-attempted-log-interval" : {
+            "type" : "number"
+          },
+          "retry-attempted-log-level" : {
+            "type" : "string"
+          },
+          "use-collision-avoidance" : {
+            "type" : "boolean"
+          },
+          "use-exponential-back-off" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.RemoveHeaderDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "name" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.RemoveHeadersDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "exclude-pattern" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "pattern" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.RemovePropertiesDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "exclude-pattern" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "pattern" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.RemovePropertyDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "name" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.ResequenceDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "batch-config" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.config.BatchResequencerConfig"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "stream-config" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.config.StreamResequencerConfig"
+          }
+        },
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.Resilience4jConfigurationDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "automatic-transition-from-open-to-half-open-enabled" : {
+            "type" : "boolean"
+          },
+          "circuit-breaker" : {
+            "type" : "string"
+          },
+          "config" : {
+            "type" : "string"
+          },
+          "failure-rate-threshold" : {
+            "type" : "number"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "minimum-number-of-calls" : {
+            "type" : "number"
+          },
+          "permitted-number-of-calls-in-half-open-state" : {
+            "type" : "number"
+          },
+          "sliding-window-size" : {
+            "type" : "number"
+          },
+          "sliding-window-type" : {
+            "type" : "string",
+            "enum" : [ "TIME_BASED", "COUNT_BASED" ]
+          },
+          "slow-call-duration-threshold" : {
+            "type" : "number"
+          },
+          "slow-call-rate-threshold" : {
+            "type" : "number"
+          },
+          "throw-exception-when-half-open-or-open-state" : {
+            "type" : "boolean"
+          },
+          "wait-duration-in-open-state" : {
+            "type" : "number"
+          },
+          "writable-stack-trace-enabled" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.RestContextRefDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "ref" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.ResumableDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "intermittent" : {
+            "type" : "boolean"
+          },
+          "resume-strategy" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "resume-strategy" ]
+      },
+      "org.apache.camel.model.RollbackDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "mark-rollback-only" : {
+              "type" : "boolean"
+            },
+            "mark-rollback-only-last" : {
+              "type" : "boolean"
+            },
+            "message" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.RouteBuilderDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string"
+            },
+            "ref" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.RouteConfigurationContextRefDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "ref" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.RouteConfigurationDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "error-handler" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ErrorHandlerDefinition"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "intercept" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.InterceptDefinition"
+              }
+            },
+            "intercept-from" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.InterceptFromDefinition"
+              }
+            },
+            "intercept-send-to-endpoint" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.InterceptSendToEndpointDefinition"
+              }
+            },
+            "on-completion" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.OnCompletionDefinition"
+              }
+            },
+            "on-exception" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.OnExceptionDefinition"
+              }
+            },
+            "precondition" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.RouteContextRefDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "ref" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.RouteDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "auto-startup" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "from" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FromDefinition"
+          },
+          "group" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "log-mask" : {
+            "type" : "boolean"
+          },
+          "message-history" : {
+            "type" : "boolean"
+          },
+          "precondition" : {
+            "type" : "string"
+          },
+          "route-configuration-id" : {
+            "type" : "string"
+          },
+          "route-policy" : {
+            "type" : "string"
+          },
+          "startup-order" : {
+            "type" : "number"
+          },
+          "stream-caching" : {
+            "type" : "boolean"
+          },
+          "trace" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "from" ]
+      },
+      "org.apache.camel.model.RouteTemplateBeanDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "bean-type" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object"
+          },
+          "property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "script" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "org.apache.camel.model.RouteTemplateDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "beans" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.NamedBeanDefinition"
+            }
+          },
+          "from" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FromDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.RouteTemplateParameterDefinition"
+            }
+          },
+          "route" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RouteDefinition"
+          }
+        },
+        "required" : [ "id" ]
+      },
+      "org.apache.camel.model.RouteTemplateParameterDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "default-value" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "required" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.RoutingSlipDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "cache-size" : {
+              "type" : "number"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "expression" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "ignore-invalid-endpoints" : {
+              "type" : "boolean"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "uri-delimiter" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ]
+      },
+      "org.apache.camel.model.SagaActionUriDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.SagaDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "compensation" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SagaActionUriDefinition"
+          },
+          "completion" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SagaActionUriDefinition"
+          },
+          "completion-mode" : {
+            "type" : "string",
+            "enum" : [ "AUTO", "MANUAL" ]
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "option" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyExpressionDefinition"
+            }
+          },
+          "propagation" : {
+            "type" : "string",
+            "enum" : [ "REQUIRED", "REQUIRES_NEW", "MANDATORY", "SUPPORTS", "NOT_SUPPORTED", "NEVER" ]
+          },
+          "saga-service" : {
+            "type" : "string"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "timeout" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.SamplingDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "message-frequency" : {
+              "type" : "number"
+            },
+            "sample-period" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.ScriptDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.SetBodyDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.SetExchangePatternDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "pattern" : {
+              "type" : "string",
+              "enum" : [ "InOnly", "InOut", "InOptionalOut" ]
+            }
+          }
+        } ],
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.SetHeaderDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SetPropertyDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SortDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "comparator" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.SplitDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-allow-null" : {
+            "type" : "boolean"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "delimiter" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-prepare" : {
+            "type" : "string"
+          },
+          "parallel-aggregate" : {
+            "type" : "boolean"
+          },
+          "parallel-processing" : {
+            "type" : "boolean"
+          },
+          "share-unit-of-work" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "stop-on-exception" : {
+            "type" : "boolean"
+          },
+          "streaming" : {
+            "type" : "boolean"
+          },
+          "timeout" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.StepDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.StopDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.TemplatedRouteBeanDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "bean-type" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object"
+          },
+          "property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "script" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "org.apache.camel.model.TemplatedRouteDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "beans" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.NamedBeanDefinition"
+            }
+          },
+          "parameters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.TemplatedRouteParameterDefinition"
+            }
+          },
+          "route-id" : {
+            "type" : "string"
+          },
+          "route-template-ref" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "route-template-ref" ]
+      },
+      "org.apache.camel.model.TemplatedRouteParameterDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name", "value" ]
+      },
+      "org.apache.camel.model.ThreadPoolProfileDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "allow-core-thread-time-out" : {
+            "type" : "boolean"
+          },
+          "default-profile" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "keep-alive-time" : {
+            "type" : "number"
+          },
+          "max-pool-size" : {
+            "type" : "number"
+          },
+          "max-queue-size" : {
+            "type" : "number"
+          },
+          "pool-size" : {
+            "type" : "number"
+          },
+          "rejected-policy" : {
+            "type" : "string",
+            "enum" : [ "Abort", "CallerRuns", "DiscardOldest", "Discard" ]
+          },
+          "time-unit" : {
+            "type" : "string",
+            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+          }
+        }
+      },
+      "org.apache.camel.model.ThreadsDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "allow-core-thread-time-out" : {
+            "type" : "boolean"
+          },
+          "caller-runs-when-rejected" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "keep-alive-time" : {
+            "type" : "number"
+          },
+          "max-pool-size" : {
+            "type" : "number"
+          },
+          "max-queue-size" : {
+            "type" : "number"
+          },
+          "pool-size" : {
+            "type" : "number"
+          },
+          "rejected-policy" : {
+            "type" : "string",
+            "enum" : [ "Abort", "CallerRuns", "DiscardOldest", "Discard" ]
+          },
+          "thread-name" : {
+            "type" : "string"
+          },
+          "time-unit" : {
+            "type" : "string",
+            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+          }
+        }
+      },
+      "org.apache.camel.model.ThrottleDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "async-delayed" : {
+            "type" : "boolean"
+          },
+          "caller-runs-when-rejected" : {
+            "type" : "boolean"
+          },
+          "correlation-expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "reject-execution" : {
+            "type" : "boolean"
+          },
+          "time-period-millis" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.ThrowExceptionDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "exception-type" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.ToDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "pattern" : {
+              "type" : "string",
+              "enum" : [ "InOnly", "InOut", "InOptionalOut" ]
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.ToDynamicDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "allow-optimised-components" : {
+              "type" : "boolean"
+            },
+            "auto-start-components" : {
+              "type" : "boolean"
+            },
+            "cache-size" : {
+              "type" : "number"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "ignore-invalid-endpoint" : {
+              "type" : "boolean"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "pattern" : {
+              "type" : "string",
+              "enum" : [ "InOnly", "InOut", "InOptionalOut" ]
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.TransactedDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.TransformDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.TryDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "do-catch" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.CatchDefinition"
+            }
+          },
+          "do-finally" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FinallyDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.UnmarshalDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "allow-null-body" : {
+            "type" : "boolean"
+          },
+          "any23" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Any23DataFormat"
+          },
+          "asn1" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+          },
+          "avro" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+          },
+          "barcode" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+          },
+          "base64" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+          },
+          "bindy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+          },
+          "cbor" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+          },
+          "crypto" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+          },
+          "csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+          },
+          "custom" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "fhir-json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+          },
+          "fhir-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+          },
+          "flatpack" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+          },
+          "grok" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+          },
+          "gzip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+          },
+          "hl7" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+          },
+          "ical" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "jackson-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+          },
+          "jaxb" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+          },
+          "json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+          },
+          "json-api" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+          },
+          "lzf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+          },
+          "mime-multipart" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+          },
+          "pgp" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+          },
+          "protobuf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+          },
+          "rss" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+          },
+          "soap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+          },
+          "syslog" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+          },
+          "tar-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+          },
+          "thrift" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+          },
+          "tidy-markup" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+          },
+          "univocity-csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+          },
+          "univocity-fixed" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+          },
+          "univocity-tsv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+          },
+          "xml-security" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+          },
+          "xstream" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+          },
+          "yaml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+          },
+          "zip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+          },
+          "zip-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+          }
+        }
+      },
+      "org.apache.camel.model.ValidateDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "predicate-exception-factory" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.WhenDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.WhenSkipSendToEndpointDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.WireTapDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "allow-optimised-components" : {
+            "type" : "boolean"
+          },
+          "auto-start-components" : {
+            "type" : "boolean"
+          },
+          "cache-size" : {
+            "type" : "number"
+          },
+          "copy" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "dynamic-uri" : {
+            "type" : "boolean"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-invalid-endpoint" : {
+            "type" : "boolean"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-prepare" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "pattern" : {
+            "type" : "string",
+            "enum" : [ "InOnly", "InOut", "InOptionalOut" ]
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "servers" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "combined-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration"
+          },
+          "consul-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+          },
+          "dns-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "kubernetes-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "static-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+          },
+          "timeout" : {
+            "type" : "number"
+          },
+          "units" : {
+            "type" : "string",
+            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "caching-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration"
+          },
+          "consul-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+          },
+          "dns-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "kubernetes-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "static-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.CombinedServiceCallServiceFilterConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "blacklist-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration"
+          },
+          "custom-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration"
+          },
+          "healthy-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "pass-through-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "acl-token" : {
+            "type" : "string"
+          },
+          "block-seconds" : {
+            "type" : "number"
+          },
+          "connect-timeout-millis" : {
+            "type" : "number"
+          },
+          "datacenter" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "password" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "read-timeout-millis" : {
+            "type" : "number"
+          },
+          "url" : {
+            "type" : "string"
+          },
+          "user-name" : {
+            "type" : "string"
+          },
+          "write-timeout-millis" : {
+            "type" : "number"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "ref" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.DefaultServiceCallServiceLoadBalancerConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "domain" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "proto" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "api-version" : {
+            "type" : "string"
+          },
+          "ca-cert-data" : {
+            "type" : "string"
+          },
+          "ca-cert-file" : {
+            "type" : "string"
+          },
+          "client-cert-data" : {
+            "type" : "string"
+          },
+          "client-cert-file" : {
+            "type" : "string"
+          },
+          "client-key-algo" : {
+            "type" : "string"
+          },
+          "client-key-data" : {
+            "type" : "string"
+          },
+          "client-key-file" : {
+            "type" : "string"
+          },
+          "client-key-passphrase" : {
+            "type" : "string"
+          },
+          "dns-domain" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "lookup" : {
+            "type" : "string",
+            "enum" : [ "environment", "dns", "client" ]
+          },
+          "master-url" : {
+            "type" : "string"
+          },
+          "namespace" : {
+            "type" : "string"
+          },
+          "oauth-token" : {
+            "type" : "string"
+          },
+          "password" : {
+            "type" : "string"
+          },
+          "port-name" : {
+            "type" : "string"
+          },
+          "port-protocol" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "trust-certs" : {
+            "type" : "boolean"
+          },
+          "username" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallConfigurationDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "blacklist-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration"
+          },
+          "caching-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration"
+          },
+          "combined-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration"
+          },
+          "combined-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceFilterConfiguration"
+          },
+          "component" : {
+            "type" : "string"
+          },
+          "consul-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+          },
+          "custom-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration"
+          },
+          "default-load-balancer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DefaultServiceCallServiceLoadBalancerConfiguration"
+          },
+          "dns-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ServiceCallExpressionConfiguration"
+          },
+          "expression-ref" : {
+            "type" : "string"
+          },
+          "healthy-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "kubernetes-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+          },
+          "load-balancer-ref" : {
+            "type" : "string"
+          },
+          "pass-through-service-filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration"
+          },
+          "pattern" : {
+            "type" : "string",
+            "enum" : [ "InOnly", "InOut", "InOptionalOut" ]
+          },
+          "service-chooser-ref" : {
+            "type" : "string"
+          },
+          "service-discovery-ref" : {
+            "type" : "string"
+          },
+          "service-filter-ref" : {
+            "type" : "string"
+          },
+          "static-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+          },
+          "uri" : {
+            "type" : "string"
+          },
+          "zookeeper-service-discovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ZooKeeperServiceCallServiceDiscoveryConfiguration"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "blacklist-service-filter" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration"
+            },
+            "caching-service-discovery" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration"
+            },
+            "combined-service-discovery" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration"
+            },
+            "combined-service-filter" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceFilterConfiguration"
+            },
+            "component" : {
+              "type" : "string"
+            },
+            "configuration-ref" : {
+              "type" : "string"
+            },
+            "consul-service-discovery" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+            },
+            "custom-service-filter" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration"
+            },
+            "default-load-balancer" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DefaultServiceCallServiceLoadBalancerConfiguration"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "dns-service-discovery" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+            },
+            "expression" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ServiceCallExpressionConfiguration"
+            },
+            "expression-ref" : {
+              "type" : "string"
+            },
+            "healthy-service-filter" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "kubernetes-service-discovery" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+            },
+            "load-balancer-ref" : {
+              "type" : "string"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "pass-through-service-filter" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration"
+            },
+            "pattern" : {
+              "type" : "string",
+              "enum" : [ "InOnly", "InOut", "InOptionalOut" ]
+            },
+            "service-chooser-ref" : {
+              "type" : "string"
+            },
+            "service-discovery-ref" : {
+              "type" : "string"
+            },
+            "service-filter-ref" : {
+              "type" : "string"
+            },
+            "static-service-discovery" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+            },
+            "uri" : {
+              "type" : "string"
+            },
+            "zookeeper-service-discovery" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ZooKeeperServiceCallServiceDiscoveryConfiguration"
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.cloud.ServiceCallExpressionConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "expression-type" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "host-header" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "port-header" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceChooserConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceFilterConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceLoadBalancerConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "servers" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ZooKeeperServiceCallServiceDiscoveryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "base-path" : {
+            "type" : "string"
+          },
+          "connection-timeout" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "namespace" : {
+            "type" : "string"
+          },
+          "nodes" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "reconnect-base-sleep-time" : {
+            "type" : "string"
+          },
+          "reconnect-max-retries" : {
+            "type" : "string"
+          },
+          "reconnect-max-sleep-time" : {
+            "type" : "string"
+          },
+          "session-timeout" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "base-path", "nodes" ]
+      },
+      "org.apache.camel.model.config.BatchResequencerConfig" : {
+        "type" : "object",
+        "properties" : {
+          "allow-duplicates" : {
+            "type" : "boolean"
+          },
+          "batch-size" : {
+            "type" : "number"
+          },
+          "batch-timeout" : {
+            "type" : "string"
+          },
+          "ignore-invalid-exchanges" : {
+            "type" : "boolean"
+          },
+          "reverse" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.config.StreamResequencerConfig" : {
+        "type" : "object",
+        "properties" : {
+          "capacity" : {
+            "type" : "number"
+          },
+          "comparator" : {
+            "type" : "string"
+          },
+          "delivery-attempt-interval" : {
+            "type" : "string"
+          },
+          "ignore-invalid-exchanges" : {
+            "type" : "boolean"
+          },
+          "reject-old" : {
+            "type" : "boolean"
+          },
+          "timeout" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ASN1DataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string"
+            },
+            "unmarshal-type" : {
+              "type" : "string"
+            },
+            "using-iterator" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.Any23DataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "base-uri" : {
+              "type" : "string"
+            },
+            "configuration" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "extractors" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "output-format" : {
+              "type" : "string",
+              "enum" : [ "NTRIPLES", "TURTLE", "NQUADS", "RDFXML", "JSONLD", "RDFJSON", "RDF4JMODEL" ]
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.AvroDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "allow-jms-type" : {
+              "type" : "boolean"
+            },
+            "allow-unmarshall-type" : {
+              "type" : "boolean"
+            },
+            "auto-discover-object-mapper" : {
+              "type" : "boolean"
+            },
+            "auto-discover-schema-resolver" : {
+              "type" : "boolean"
+            },
+            "collection-type" : {
+              "type" : "string"
+            },
+            "content-type-header" : {
+              "type" : "boolean"
+            },
+            "disable-features" : {
+              "type" : "string"
+            },
+            "enable-features" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "include" : {
+              "type" : "string"
+            },
+            "instance-class-name" : {
+              "type" : "string"
+            },
+            "json-view" : {
+              "type" : "string"
+            },
+            "library" : {
+              "type" : "string",
+              "enum" : [ "ApacheAvro", "Jackson" ]
+            },
+            "module-class-names" : {
+              "type" : "string"
+            },
+            "module-refs" : {
+              "type" : "string"
+            },
+            "object-mapper" : {
+              "type" : "string"
+            },
+            "schema-resolver" : {
+              "type" : "string"
+            },
+            "timezone" : {
+              "type" : "string"
+            },
+            "unmarshal-type" : {
+              "type" : "string"
+            },
+            "use-default-object-mapper" : {
+              "type" : "boolean"
+            },
+            "use-list" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.BarcodeDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "barcode-format" : {
+            "type" : "string"
+          },
+          "height" : {
+            "type" : "number"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "image-type" : {
+            "type" : "string"
+          },
+          "width" : {
+            "type" : "number"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.Base64DataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "line-length" : {
+            "type" : "number"
+          },
+          "line-separator" : {
+            "type" : "string"
+          },
+          "url-safe" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.BindyDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-empty-stream" : {
+            "type" : "boolean"
+          },
+          "class-type" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "locale" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "Csv", "Fixed", "KeyValue" ]
+          },
+          "unwrap-single-instance" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "type" ]
+      },
+      "org.apache.camel.model.dataformat.CBORDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-jms-type" : {
+            "type" : "boolean"
+          },
+          "allow-unmarshall-type" : {
+            "type" : "boolean"
+          },
+          "collection-type" : {
+            "type" : "string"
+          },
+          "disable-features" : {
+            "type" : "string"
+          },
+          "enable-features" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "object-mapper" : {
+            "type" : "string"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "unmarshal-type" : {
+            "type" : "string"
+          },
+          "use-default-object-mapper" : {
+            "type" : "boolean"
+          },
+          "use-list" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.CryptoDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "algorithm" : {
+            "type" : "string"
+          },
+          "algorithm-parameter-ref" : {
+            "type" : "string"
+          },
+          "buffer-size" : {
+            "type" : "number"
+          },
+          "crypto-provider" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "init-vector-ref" : {
+            "type" : "string"
+          },
+          "inline" : {
+            "type" : "boolean"
+          },
+          "key-ref" : {
+            "type" : "string"
+          },
+          "mac-algorithm" : {
+            "type" : "string"
+          },
+          "should-append-hmac" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.CsvDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "allow-missing-column-names" : {
+              "type" : "boolean"
+            },
+            "capture-header-record" : {
+              "type" : "boolean"
+            },
+            "comment-marker" : {
+              "type" : "string"
+            },
+            "comment-marker-disabled" : {
+              "type" : "boolean"
+            },
+            "delimiter" : {
+              "type" : "string"
+            },
+            "escape" : {
+              "type" : "string"
+            },
+            "escape-disabled" : {
+              "type" : "boolean"
+            },
+            "format-name" : {
+              "type" : "string",
+              "enum" : [ "DEFAULT", "EXCEL", "INFORMIX_UNLOAD", "INFORMIX_UNLOAD_CSV", "MYSQL", "RFC4180" ]
+            },
+            "format-ref" : {
+              "type" : "string"
+            },
+            "header" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "header-disabled" : {
+              "type" : "boolean"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "ignore-empty-lines" : {
+              "type" : "boolean"
+            },
+            "ignore-header-case" : {
+              "type" : "boolean"
+            },
+            "ignore-surrounding-spaces" : {
+              "type" : "boolean"
+            },
+            "lazy-load" : {
+              "type" : "boolean"
+            },
+            "marshaller-factory-ref" : {
+              "type" : "string"
+            },
+            "null-string" : {
+              "type" : "string"
+            },
+            "null-string-disabled" : {
+              "type" : "boolean"
+            },
+            "quote" : {
+              "type" : "string"
+            },
+            "quote-disabled" : {
+              "type" : "boolean"
+            },
+            "quote-mode" : {
+              "type" : "string",
+              "enum" : [ "ALL", "ALL_NON_NULL", "MINIMAL", "NON_NUMERIC", "NONE" ]
+            },
+            "record-converter-ref" : {
+              "type" : "string"
+            },
+            "record-separator" : {
+              "type" : "string"
+            },
+            "record-separator-disabled" : {
+              "type" : "string"
+            },
+            "skip-header-record" : {
+              "type" : "boolean"
+            },
+            "trailing-delimiter" : {
+              "type" : "boolean"
+            },
+            "trim" : {
+              "type" : "boolean"
+            },
+            "use-maps" : {
+              "type" : "boolean"
+            },
+            "use-ordered-maps" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.CustomDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string"
+            },
+            "ref" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.dataformat.DataFormatsDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "any23" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Any23DataFormat"
+          },
+          "asn1" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+          },
+          "avro" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+          },
+          "barcode" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+          },
+          "base64" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+          },
+          "bindy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+          },
+          "cbor" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+          },
+          "crypto" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+          },
+          "csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+          },
+          "custom" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+          },
+          "fhir-json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+          },
+          "fhir-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+          },
+          "flatpack" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+          },
+          "grok" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+          },
+          "gzip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+          },
+          "hl7" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+          },
+          "ical" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+          },
+          "jackson-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+          },
+          "jaxb" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+          },
+          "json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+          },
+          "json-api" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+          },
+          "lzf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+          },
+          "mime-multipart" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+          },
+          "pgp" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+          },
+          "protobuf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+          },
+          "rss" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+          },
+          "soap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+          },
+          "syslog" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+          },
+          "tar-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+          },
+          "thrift" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+          },
+          "tidy-markup" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+          },
+          "univocity-csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+          },
+          "univocity-fixed" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+          },
+          "univocity-tsv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+          },
+          "xml-security" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+          },
+          "xstream" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+          },
+          "yaml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+          },
+          "zip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+          },
+          "zip-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.FhirJsonDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "dont-encode-elements" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "dont-strip-versions-from-references-at-paths" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "encode-elements" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "encode-elements-applies-to-child-resources-only" : {
+            "type" : "boolean"
+          },
+          "fhir-version" : {
+            "type" : "string",
+            "enum" : [ "DSTU2", "DSTU2_HL7ORG", "DSTU2_1", "DSTU3", "R4", "R5" ]
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "omit-resource-id" : {
+            "type" : "boolean"
+          },
+          "override-resource-id-with-bundle-entry-full-url" : {
+            "type" : "boolean"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "server-base-url" : {
+            "type" : "string"
+          },
+          "strip-versions-from-references" : {
+            "type" : "boolean"
+          },
+          "summary-mode" : {
+            "type" : "boolean"
+          },
+          "suppress-narratives" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.FhirXmlDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "dont-encode-elements" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "dont-strip-versions-from-references-at-paths" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "encode-elements" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "encode-elements-applies-to-child-resources-only" : {
+            "type" : "boolean"
+          },
+          "fhir-version" : {
+            "type" : "string",
+            "enum" : [ "DSTU2", "DSTU2_HL7ORG", "DSTU2_1", "DSTU3", "R4", "R5" ]
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "omit-resource-id" : {
+            "type" : "boolean"
+          },
+          "override-resource-id-with-bundle-entry-full-url" : {
+            "type" : "boolean"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "server-base-url" : {
+            "type" : "string"
+          },
+          "strip-versions-from-references" : {
+            "type" : "boolean"
+          },
+          "summary-mode" : {
+            "type" : "boolean"
+          },
+          "suppress-narratives" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.FlatpackDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-short-lines" : {
+            "type" : "boolean"
+          },
+          "definition" : {
+            "type" : "string"
+          },
+          "delimiter" : {
+            "type" : "string"
+          },
+          "fixed" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-extra-columns" : {
+            "type" : "boolean"
+          },
+          "ignore-first-record" : {
+            "type" : "boolean"
+          },
+          "parser-factory-ref" : {
+            "type" : "string"
+          },
+          "text-qualifier" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.GrokDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-multiple-matches-per-line" : {
+            "type" : "boolean"
+          },
+          "flattened" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "named-only" : {
+            "type" : "boolean"
+          },
+          "pattern" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.dataformat.GzipDeflaterDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.HL7DataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "validate" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.IcalDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "validating" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.JacksonXMLDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-jms-type" : {
+            "type" : "boolean"
+          },
+          "allow-unmarshall-type" : {
+            "type" : "boolean"
+          },
+          "collection-type" : {
+            "type" : "string"
+          },
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "disable-features" : {
+            "type" : "string"
+          },
+          "enable-features" : {
+            "type" : "string"
+          },
+          "enable-jaxb-annotation-module" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "include" : {
+            "type" : "string"
+          },
+          "json-view" : {
+            "type" : "string"
+          },
+          "module-class-names" : {
+            "type" : "string"
+          },
+          "module-refs" : {
+            "type" : "string"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "timezone" : {
+            "type" : "string"
+          },
+          "unmarshal-type" : {
+            "type" : "string"
+          },
+          "use-list" : {
+            "type" : "boolean"
+          },
+          "xml-mapper" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.JaxbDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "context-path" : {
+            "type" : "string"
+          },
+          "context-path-is-class-name" : {
+            "type" : "boolean"
+          },
+          "encoding" : {
+            "type" : "string"
+          },
+          "filter-non-xml-chars" : {
+            "type" : "boolean"
+          },
+          "fragment" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-jaxb-element" : {
+            "type" : "boolean"
+          },
+          "jaxb-provider-properties" : {
+            "type" : "string"
+          },
+          "must-be-jaxb-element" : {
+            "type" : "boolean"
+          },
+          "namespace-prefix-ref" : {
+            "type" : "string"
+          },
+          "no-namespace-schema-location" : {
+            "type" : "string"
+          },
+          "object-factory" : {
+            "type" : "boolean"
+          },
+          "part-class" : {
+            "type" : "string"
+          },
+          "part-namespace" : {
+            "type" : "string"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "schema" : {
+            "type" : "string"
+          },
+          "schema-location" : {
+            "type" : "string"
+          },
+          "schema-severity-level" : {
+            "type" : "string",
+            "enum" : [ "0", "1", "2" ]
+          },
+          "xml-stream-writer-wrapper" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "context-path" ]
+      },
+      "org.apache.camel.model.dataformat.JsonApiDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "main-format-type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.JsonDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-jms-type" : {
+            "type" : "boolean"
+          },
+          "allow-unmarshall-type" : {
+            "type" : "boolean"
+          },
+          "auto-discover-object-mapper" : {
+            "type" : "boolean"
+          },
+          "auto-discover-schema-resolver" : {
+            "type" : "boolean"
+          },
+          "collection-type" : {
+            "type" : "string"
+          },
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "disable-features" : {
+            "type" : "string"
+          },
+          "drop-root-node" : {
+            "type" : "boolean"
+          },
+          "enable-features" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "include" : {
+            "type" : "string"
+          },
+          "json-view" : {
+            "type" : "string"
+          },
+          "library" : {
+            "type" : "string",
+            "enum" : [ "Fastjson", "Gson", "Jackson", "Johnzon", "Jsonb", "XStream" ]
+          },
+          "module-class-names" : {
+            "type" : "string"
+          },
+          "module-refs" : {
+            "type" : "string"
+          },
+          "naming-strategy" : {
+            "type" : "string"
+          },
+          "object-mapper" : {
+            "type" : "string"
+          },
+          "permissions" : {
+            "type" : "string"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "schema-resolver" : {
+            "type" : "string"
+          },
+          "timezone" : {
+            "type" : "string"
+          },
+          "unmarshal-type" : {
+            "type" : "string"
+          },
+          "use-default-object-mapper" : {
+            "type" : "boolean"
+          },
+          "use-list" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.LZFDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "using-parallel-compression" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.MimeMultipartDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "binary-content" : {
+            "type" : "boolean"
+          },
+          "headers-inline" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "include-headers" : {
+            "type" : "string"
+          },
+          "multipart-sub-type" : {
+            "type" : "string"
+          },
+          "multipart-without-attachment" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.PGPDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "algorithm" : {
+            "type" : "number"
+          },
+          "armored" : {
+            "type" : "boolean"
+          },
+          "compression-algorithm" : {
+            "type" : "number"
+          },
+          "hash-algorithm" : {
+            "type" : "number"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "integrity" : {
+            "type" : "boolean"
+          },
+          "key-file-name" : {
+            "type" : "string"
+          },
+          "key-userid" : {
+            "type" : "string"
+          },
+          "password" : {
+            "type" : "string"
+          },
+          "provider" : {
+            "type" : "string"
+          },
+          "signature-key-file-name" : {
+            "type" : "string"
+          },
+          "signature-key-ring" : {
+            "type" : "string"
+          },
+          "signature-key-userid" : {
+            "type" : "string"
+          },
+          "signature-password" : {
+            "type" : "string"
+          },
+          "signature-verification-option" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ProtobufDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "allow-jms-type" : {
+              "type" : "boolean"
+            },
+            "allow-unmarshall-type" : {
+              "type" : "boolean"
+            },
+            "auto-discover-object-mapper" : {
+              "type" : "boolean"
+            },
+            "auto-discover-schema-resolver" : {
+              "type" : "boolean"
+            },
+            "collection-type" : {
+              "type" : "string"
+            },
+            "content-type-format" : {
+              "type" : "string",
+              "enum" : [ "native", "json" ]
+            },
+            "content-type-header" : {
+              "type" : "boolean"
+            },
+            "disable-features" : {
+              "type" : "string"
+            },
+            "enable-features" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "include" : {
+              "type" : "string"
+            },
+            "instance-class" : {
+              "type" : "string"
+            },
+            "json-view" : {
+              "type" : "string"
+            },
+            "library" : {
+              "type" : "string",
+              "enum" : [ "GoogleProtobuf", "Jackson" ]
+            },
+            "module-class-names" : {
+              "type" : "string"
+            },
+            "module-refs" : {
+              "type" : "string"
+            },
+            "object-mapper" : {
+              "type" : "string"
+            },
+            "schema-resolver" : {
+              "type" : "string"
+            },
+            "timezone" : {
+              "type" : "string"
+            },
+            "unmarshal-type" : {
+              "type" : "string"
+            },
+            "use-default-object-mapper" : {
+              "type" : "boolean"
+            },
+            "use-list" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.RssDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.SoapDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "context-path" : {
+              "type" : "string"
+            },
+            "element-name-strategy-ref" : {
+              "type" : "string"
+            },
+            "encoding" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "namespace-prefix-ref" : {
+              "type" : "string"
+            },
+            "schema" : {
+              "type" : "string"
+            },
+            "version" : {
+              "type" : "string",
+              "enum" : [ "1.1", "1.2" ]
+            }
+          }
+        } ],
+        "required" : [ "context-path" ]
+      },
+      "org.apache.camel.model.dataformat.SyslogDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.TarFileDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-empty-directory" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "max-decompressed-size" : {
+            "type" : "number"
+          },
+          "preserve-path-elements" : {
+            "type" : "boolean"
+          },
+          "using-iterator" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ThriftDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "content-type-format" : {
+              "type" : "string",
+              "enum" : [ "binary", "json", "sjson" ]
+            },
+            "content-type-header" : {
+              "type" : "boolean"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "instance-class" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.TidyMarkupDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "data-object-type" : {
+            "type" : "string",
+            "enum" : [ "org.w3c.dom.Node", "java.lang.String" ]
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "omit-xml-declaration" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityCsvDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "as-map" : {
+            "type" : "boolean"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "delimiter" : {
+            "type" : "string"
+          },
+          "empty-value" : {
+            "type" : "string"
+          },
+          "header-extraction-enabled" : {
+            "type" : "boolean"
+          },
+          "headers-disabled" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-leading-whitespaces" : {
+            "type" : "boolean"
+          },
+          "ignore-trailing-whitespaces" : {
+            "type" : "boolean"
+          },
+          "lazy-load" : {
+            "type" : "boolean"
+          },
+          "line-separator" : {
+            "type" : "string"
+          },
+          "normalized-line-separator" : {
+            "type" : "string"
+          },
+          "null-value" : {
+            "type" : "string"
+          },
+          "number-of-records-to-read" : {
+            "type" : "number"
+          },
+          "quote" : {
+            "type" : "string"
+          },
+          "quote-all-fields" : {
+            "type" : "boolean"
+          },
+          "quote-escape" : {
+            "type" : "string"
+          },
+          "skip-empty-lines" : {
+            "type" : "boolean"
+          },
+          "univocity-header" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityHeader"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityFixedDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "as-map" : {
+            "type" : "boolean"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "empty-value" : {
+            "type" : "string"
+          },
+          "header-extraction-enabled" : {
+            "type" : "boolean"
+          },
+          "headers-disabled" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-leading-whitespaces" : {
+            "type" : "boolean"
+          },
+          "ignore-trailing-whitespaces" : {
+            "type" : "boolean"
+          },
+          "lazy-load" : {
+            "type" : "boolean"
+          },
+          "line-separator" : {
+            "type" : "string"
+          },
+          "normalized-line-separator" : {
+            "type" : "string"
+          },
+          "null-value" : {
+            "type" : "string"
+          },
+          "number-of-records-to-read" : {
+            "type" : "number"
+          },
+          "padding" : {
+            "type" : "string"
+          },
+          "record-ends-on-newline" : {
+            "type" : "boolean"
+          },
+          "skip-empty-lines" : {
+            "type" : "boolean"
+          },
+          "skip-trailing-chars-until-newline" : {
+            "type" : "boolean"
+          },
+          "univocity-header" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityHeader"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityHeader" : {
+        "type" : "object",
+        "properties" : {
+          "length" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityTsvDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "as-map" : {
+            "type" : "boolean"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "empty-value" : {
+            "type" : "string"
+          },
+          "escape-char" : {
+            "type" : "string"
+          },
+          "header-extraction-enabled" : {
+            "type" : "boolean"
+          },
+          "headers-disabled" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-leading-whitespaces" : {
+            "type" : "boolean"
+          },
+          "ignore-trailing-whitespaces" : {
+            "type" : "boolean"
+          },
+          "lazy-load" : {
+            "type" : "boolean"
+          },
+          "line-separator" : {
+            "type" : "string"
+          },
+          "normalized-line-separator" : {
+            "type" : "string"
+          },
+          "null-value" : {
+            "type" : "string"
+          },
+          "number-of-records-to-read" : {
+            "type" : "number"
+          },
+          "skip-empty-lines" : {
+            "type" : "boolean"
+          },
+          "univocity-header" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityHeader"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.XMLSecurityDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "add-key-value-for-encrypted-key" : {
+            "type" : "boolean"
+          },
+          "digest-algorithm" : {
+            "type" : "string",
+            "enum" : [ "SHA1", "SHA256", "SHA512" ]
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "key-cipher-algorithm" : {
+            "type" : "string",
+            "enum" : [ "RSA_v1dot5", "RSA_OAEP", "RSA_OAEP_11" ]
+          },
+          "key-or-trust-store-parameters-ref" : {
+            "type" : "string"
+          },
+          "key-password" : {
+            "type" : "string"
+          },
+          "mgf-algorithm" : {
+            "type" : "string",
+            "enum" : [ "MGF1_SHA1", "MGF1_SHA256", "MGF1_SHA512" ]
+          },
+          "pass-phrase" : {
+            "type" : "string"
+          },
+          "pass-phrase-byte" : {
+            "type" : "string"
+          },
+          "recipient-key-alias" : {
+            "type" : "string"
+          },
+          "secure-tag" : {
+            "type" : "string"
+          },
+          "secure-tag-contents" : {
+            "type" : "boolean"
+          },
+          "xml-cipher-algorithm" : {
+            "type" : "string",
+            "enum" : [ "TRIPLEDES", "AES_128", "AES_128_GCM", "AES_192", "AES_192_GCM", "AES_256", "AES_256_GCM", "SEED_128", "CAMELLIA_128", "CAMELLIA_192", "CAMELLIA_256" ]
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.XStreamDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "aliases" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "content-type-header" : {
+              "type" : "boolean"
+            },
+            "converters" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "driver" : {
+              "type" : "string"
+            },
+            "driver-ref" : {
+              "type" : "string"
+            },
+            "encoding" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "implicit-collections" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "mode" : {
+              "type" : "string",
+              "enum" : [ "NO_REFERENCES", "ID_REFERENCES", "XPATH_RELATIVE_REFERENCES", "XPATH_ABSOLUTE_REFERENCES", "SINGLE_NODE_XPATH_RELATIVE_REFERENCES", "SINGLE_NODE_XPATH_ABSOLUTE_REFERENCES" ]
+            },
+            "omit-fields" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "permissions" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.YAMLDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-any-type" : {
+            "type" : "boolean"
+          },
+          "allow-recursive-keys" : {
+            "type" : "boolean"
+          },
+          "constructor" : {
+            "type" : "string"
+          },
+          "dumper-options" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "library" : {
+            "type" : "string",
+            "enum" : [ "SnakeYAML" ]
+          },
+          "max-aliases-for-collections" : {
+            "type" : "number"
+          },
+          "pretty-flow" : {
+            "type" : "boolean"
+          },
+          "representer" : {
+            "type" : "string"
+          },
+          "resolver" : {
+            "type" : "string"
+          },
+          "type-filter" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLTypeFilterDefinition"
+            }
+          },
+          "unmarshal-type" : {
+            "type" : "string"
+          },
+          "use-application-context-class-loader" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.YAMLTypeFilterDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ZipDeflaterDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "compression-level" : {
+            "type" : "string",
+            "enum" : [ "-1", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" ]
+          },
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ZipFileDataFormat" : {
+        "type" : "object",
+        "properties" : {
+          "allow-empty-directory" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "max-decompressed-size" : {
+            "type" : "number"
+          },
+          "preserve-path-elements" : {
+            "type" : "boolean"
+          },
+          "using-iterator" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.DeadLetterChannelDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "dead-letter-handle-new-exception" : {
+            "type" : "boolean"
+          },
+          "dead-letter-uri" : {
+            "type" : "string"
+          },
+          "executor-service-ref" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "level" : {
+            "type" : "string",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "log-name" : {
+            "type" : "string"
+          },
+          "logger-ref" : {
+            "type" : "string"
+          },
+          "on-exception-occurred-ref" : {
+            "type" : "string"
+          },
+          "on-prepare-failure-ref" : {
+            "type" : "string"
+          },
+          "on-redelivery-ref" : {
+            "type" : "string"
+          },
+          "redelivery-policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redelivery-policy-ref" : {
+            "type" : "string"
+          },
+          "retry-while-ref" : {
+            "type" : "string"
+          },
+          "use-original-body" : {
+            "type" : "boolean"
+          },
+          "use-original-message" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "dead-letter-uri" ]
+      },
+      "org.apache.camel.model.errorhandler.DefaultErrorHandlerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "executor-service-ref" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "level" : {
+            "type" : "string",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "log-name" : {
+            "type" : "string"
+          },
+          "logger-ref" : {
+            "type" : "string"
+          },
+          "on-exception-occurred-ref" : {
+            "type" : "string"
+          },
+          "on-prepare-failure-ref" : {
+            "type" : "string"
+          },
+          "on-redelivery-ref" : {
+            "type" : "string"
+          },
+          "redelivery-policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redelivery-policy-ref" : {
+            "type" : "string"
+          },
+          "retry-while-ref" : {
+            "type" : "string"
+          },
+          "use-original-body" : {
+            "type" : "boolean"
+          },
+          "use-original-message" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.ErrorHandlerRefDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.errorhandler.JtaTransactionErrorHandlerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "executor-service-ref" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "level" : {
+            "type" : "string",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "log-name" : {
+            "type" : "string"
+          },
+          "logger-ref" : {
+            "type" : "string"
+          },
+          "on-exception-occurred-ref" : {
+            "type" : "string"
+          },
+          "on-prepare-failure-ref" : {
+            "type" : "string"
+          },
+          "on-redelivery-ref" : {
+            "type" : "string"
+          },
+          "redelivery-policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redelivery-policy-ref" : {
+            "type" : "string"
+          },
+          "retry-while-ref" : {
+            "type" : "string"
+          },
+          "rollback-logging-level" : {
+            "type" : "string",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "transacted-policy-ref" : {
+            "type" : "string"
+          },
+          "use-original-body" : {
+            "type" : "boolean"
+          },
+          "use-original-message" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.NoErrorHandlerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.SpringTransactionErrorHandlerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "executor-service-ref" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "level" : {
+            "type" : "string",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "log-name" : {
+            "type" : "string"
+          },
+          "logger-ref" : {
+            "type" : "string"
+          },
+          "on-exception-occurred-ref" : {
+            "type" : "string"
+          },
+          "on-prepare-failure-ref" : {
+            "type" : "string"
+          },
+          "on-redelivery-ref" : {
+            "type" : "string"
+          },
+          "redelivery-policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redelivery-policy-ref" : {
+            "type" : "string"
+          },
+          "retry-while-ref" : {
+            "type" : "string"
+          },
+          "rollback-logging-level" : {
+            "type" : "string",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "transacted-policy-ref" : {
+            "type" : "string"
+          },
+          "use-original-body" : {
+            "type" : "boolean"
+          },
+          "use-original-message" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.language.CSimpleExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ConstantExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.DatasonnetExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "body-media-type" : {
+              "type" : "string"
+            },
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "output-media-type" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ExchangePropertyExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ExpressionDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "constant" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+          },
+          "csimple" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.CSimpleExpression"
+          },
+          "datasonnet" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.DatasonnetExpression"
+          },
+          "exchange-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "exchangeProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "groovy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.GroovyExpression"
+          },
+          "header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+          },
+          "hl7terser" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+          },
+          "joor" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JoorExpression"
+          },
+          "jq" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+          },
+          "jsonpath" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+          },
+          "language" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.LanguageExpression"
+          },
+          "method" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.MethodCallExpression"
+          },
+          "mvel" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.MvelExpression"
+          },
+          "ognl" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.OgnlExpression"
+          },
+          "ref" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.RefExpression"
+          },
+          "simple" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+          },
+          "spel" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.SpELExpression"
+          },
+          "tokenize" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.TokenizerExpression"
+          },
+          "xpath" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.XPathExpression"
+          },
+          "xquery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.XQueryExpression"
+          },
+          "xtokenize" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+          }
+        }
+      },
+      "org.apache.camel.model.language.GroovyExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.HeaderExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.Hl7TerserExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JoorExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "pre-compile" : {
+              "type" : "boolean"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "single-quotes" : {
+              "type" : "boolean"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JqExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JsonPathExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "allow-easy-predicate" : {
+              "type" : "boolean"
+            },
+            "allow-simple" : {
+              "type" : "boolean"
+            },
+            "expression" : {
+              "type" : "string"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "option" : {
+              "type" : "string",
+              "enum" : [ "DEFAULT_PATH_LEAF_TO_NULL", "ALWAYS_RETURN_LIST", "AS_PATH_LIST", "SUPPRESS_EXCEPTIONS", "REQUIRE_PROPERTIES" ]
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "suppress-exceptions" : {
+              "type" : "boolean"
+            },
+            "trim" : {
+              "type" : "boolean"
+            },
+            "unpack-array" : {
+              "type" : "boolean"
+            },
+            "write-as-string" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.LanguageExpression" : {
+        "type" : "object",
+        "properties" : {
+          "expression" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "language" : {
+            "type" : "string"
+          },
+          "trim" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "expression", "language" ]
+      },
+      "org.apache.camel.model.language.MethodCallExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "bean-type" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "method" : {
+              "type" : "string"
+            },
+            "ref" : {
+              "type" : "string"
+            },
+            "scope" : {
+              "type" : "string",
+              "enum" : [ "Singleton", "Request", "Prototype" ]
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.language.MvelExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.OgnlExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.RefExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.SimpleExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.SpELExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.TokenizerExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "end-token" : {
+              "type" : "string"
+            },
+            "group" : {
+              "type" : "string"
+            },
+            "group-delimiter" : {
+              "type" : "string"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "include-tokens" : {
+              "type" : "boolean"
+            },
+            "inherit-namespace-tag-name" : {
+              "type" : "string"
+            },
+            "regex" : {
+              "type" : "boolean"
+            },
+            "skip-first" : {
+              "type" : "boolean"
+            },
+            "token" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            },
+            "xml" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "token" ]
+      },
+      "org.apache.camel.model.language.XMLTokenizerExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "group" : {
+              "type" : "number"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "mode" : {
+              "type" : "string",
+              "enum" : [ "i", "w", "u", "t" ]
+            },
+            "namespace" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.language.XPathExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "document-type" : {
+              "type" : "string"
+            },
+            "expression" : {
+              "type" : "string"
+            },
+            "factory-ref" : {
+              "type" : "string"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "log-namespaces" : {
+              "type" : "boolean"
+            },
+            "namespace" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "object-model" : {
+              "type" : "string"
+            },
+            "pre-compile" : {
+              "type" : "boolean"
+            },
+            "result-type" : {
+              "type" : "string",
+              "enum" : [ "NUMBER", "STRING", "BOOLEAN", "NODESET", "NODE" ]
+            },
+            "saxon" : {
+              "type" : "boolean"
+            },
+            "thread-safety" : {
+              "type" : "boolean"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.XQueryExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "configuration-ref" : {
+              "type" : "string"
+            },
+            "expression" : {
+              "type" : "string"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "namespace" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "trim" : {
+              "type" : "boolean"
+            },
+            "type" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string"
+            },
+            "ref" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "exception" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "maximum-failover-attempts" : {
+            "type" : "string"
+          },
+          "round-robin" : {
+            "type" : "string"
+          },
+          "sticky" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.StickyLoadBalancerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "correlation-expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "distribution-ratio" : {
+            "type" : "string"
+          },
+          "distribution-ratio-delimiter" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "round-robin" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "distribution-ratio" ]
+      },
+      "org.apache.camel.model.rest.ApiKeyDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "in-cookie" : {
+            "type" : "boolean"
+          },
+          "in-header" : {
+            "type" : "boolean"
+          },
+          "in-query" : {
+            "type" : "boolean"
+          },
+          "key" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key", "name" ]
+      },
+      "org.apache.camel.model.rest.BasicAuthDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "key" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.BearerTokenDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "format" : {
+            "type" : "string"
+          },
+          "key" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.DeleteDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-docs" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "out-type" : {
+            "type" : "string"
+          },
+          "param" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string"
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "response-message" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "security" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.GetDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-docs" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "out-type" : {
+            "type" : "string"
+          },
+          "param" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string"
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "response-message" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "security" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.HeadDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-docs" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "out-type" : {
+            "type" : "string"
+          },
+          "param" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string"
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "response-message" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "security" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.MutualTLSDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "key" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.OAuth2Definition" : {
+        "type" : "object",
+        "properties" : {
+          "authorization-url" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "flow" : {
+            "type" : "string",
+            "enum" : [ "implicit", "password", "application", "clientCredentials", "accessCode", "authorizationCode" ]
+          },
+          "key" : {
+            "type" : "string"
+          },
+          "refresh-url" : {
+            "type" : "string"
+          },
+          "scopes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "token-url" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.OpenIdConnectDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "key" : {
+            "type" : "string"
+          },
+          "url" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key", "url" ]
+      },
+      "org.apache.camel.model.rest.ParamDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "array-type" : {
+            "type" : "string"
+          },
+          "collection-format" : {
+            "type" : "string",
+            "enum" : [ "csv", "multi", "pipes", "ssv", "tsv" ]
+          },
+          "data-format" : {
+            "type" : "string"
+          },
+          "data-type" : {
+            "type" : "string"
+          },
+          "default-value" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "examples" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "body", "formData", "header", "path", "query" ]
+          },
+          "value" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "org.apache.camel.model.rest.PatchDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-docs" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "out-type" : {
+            "type" : "string"
+          },
+          "param" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string"
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "response-message" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "security" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.PostDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-docs" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "out-type" : {
+            "type" : "string"
+          },
+          "param" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string"
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "response-message" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "security" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.PutDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-docs" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "out-type" : {
+            "type" : "string"
+          },
+          "param" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string"
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "response-message" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "security" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.ResponseHeaderDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "array-type" : {
+            "type" : "string"
+          },
+          "collection-format" : {
+            "type" : "string",
+            "enum" : [ "csv", "multi", "pipes", "ssv", "tsv" ]
+          },
+          "data-format" : {
+            "type" : "string"
+          },
+          "data-type" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "example" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.rest.ResponseMessageDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "string"
+          },
+          "examples" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "header" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseHeaderDefinition"
+            }
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "response-model" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "message" ]
+      },
+      "org.apache.camel.model.rest.RestBindingDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "component" : {
+            "type" : "string"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "out-type" : {
+            "type" : "string"
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestConfigurationDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-component" : {
+            "type" : "string",
+            "enum" : [ "openapi", "swagger" ]
+          },
+          "api-context-path" : {
+            "type" : "string"
+          },
+          "api-host" : {
+            "type" : "string"
+          },
+          "api-property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "api-vendor-extension" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "auto", "json", "json_xml", "off", "xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "component" : {
+            "type" : "string",
+            "enum" : [ "platform-http", "servlet", "jetty", "undertow", "netty-http", "coap" ]
+          },
+          "component-property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "consumer-property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "context-path" : {
+            "type" : "string"
+          },
+          "cors-headers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "data-format-property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "endpoint-property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "host" : {
+            "type" : "string"
+          },
+          "host-name-resolver" : {
+            "type" : "string",
+            "enum" : [ "allLocalIp", "localHostName", "localIp" ]
+          },
+          "json-data-format" : {
+            "type" : "string"
+          },
+          "port" : {
+            "type" : "string"
+          },
+          "producer-api-doc" : {
+            "type" : "string"
+          },
+          "producer-component" : {
+            "type" : "string",
+            "enum" : [ "vertx-http", "http", "undertow", "netty-http" ]
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "use-x-forward-headers" : {
+            "type" : "boolean"
+          },
+          "xml-data-format" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-docs" : {
+            "type" : "boolean"
+          },
+          "binding-mode" : {
+            "type" : "string",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "client-request-validation" : {
+            "type" : "boolean"
+          },
+          "consumes" : {
+            "type" : "string"
+          },
+          "delete" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.DeleteDefinition"
+            }
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enable-cors" : {
+            "type" : "boolean"
+          },
+          "get" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.GetDefinition"
+            }
+          },
+          "head" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.HeadDefinition"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "patch" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.PatchDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string"
+          },
+          "post" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.PostDefinition"
+            }
+          },
+          "produces" : {
+            "type" : "string"
+          },
+          "put" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.PutDefinition"
+            }
+          },
+          "security-definitions" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestSecuritiesDefinition"
+          },
+          "security-requirements" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skip-binding-on-error-code" : {
+            "type" : "boolean"
+          },
+          "tag" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestPropertyDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key", "value" ]
+      },
+      "org.apache.camel.model.rest.RestSecuritiesDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "api-key" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.ApiKeyDefinition"
+          },
+          "basic-auth" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.BasicAuthDefinition"
+          },
+          "bearer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.BearerTokenDefinition"
+          },
+          "mutual-tls" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.MutualTLSDefinition"
+          },
+          "oauth2" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.OAuth2Definition"
+          },
+          "open-id-connect" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.OpenIdConnectDefinition"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestsDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "rest" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.rest.SecurityDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "scopes" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.transformer.CustomTransformerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "class-name" : {
+            "type" : "string"
+          },
+          "from-type" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "to-type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.transformer.DataFormatTransformerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "any23" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Any23DataFormat"
+          },
+          "asn1" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+          },
+          "avro" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+          },
+          "barcode" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+          },
+          "base64" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+          },
+          "bindy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+          },
+          "cbor" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+          },
+          "crypto" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+          },
+          "csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+          },
+          "custom" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+          },
+          "fhir-json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+          },
+          "fhir-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+          },
+          "flatpack" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+          },
+          "from-type" : {
+            "type" : "string"
+          },
+          "grok" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+          },
+          "gzip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+          },
+          "hl7" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+          },
+          "ical" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+          },
+          "jackson-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+          },
+          "jaxb" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+          },
+          "json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+          },
+          "json-api" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+          },
+          "lzf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+          },
+          "mime-multipart" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+          },
+          "pgp" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+          },
+          "protobuf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+          },
+          "rss" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "soap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+          },
+          "syslog" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+          },
+          "tar-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+          },
+          "thrift" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+          },
+          "tidy-markup" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+          },
+          "to-type" : {
+            "type" : "string"
+          },
+          "univocity-csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+          },
+          "univocity-fixed" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+          },
+          "univocity-tsv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+          },
+          "xml-security" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+          },
+          "xstream" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+          },
+          "yaml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+          },
+          "zip-deflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+          },
+          "zip-file" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+          }
+        }
+      },
+      "org.apache.camel.model.transformer.EndpointTransformerDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "from-type" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "to-type" : {
+            "type" : "string"
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.transformer.TransformersDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "custom-transformer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.transformer.CustomTransformerDefinition"
+          },
+          "data-format-transformer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.transformer.DataFormatTransformerDefinition"
+          },
+          "endpoint-transformer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.transformer.EndpointTransformerDefinition"
+          }
+        }
+      },
+      "org.apache.camel.model.validator.CustomValidatorDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "class-name" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.validator.EndpointValidatorDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "ref" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.validator.PredicateValidatorDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.validator.ValidatorsDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "custom-validator" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.validator.CustomValidatorDefinition"
+          },
+          "endpoint-validator" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.validator.EndpointValidatorDefinition"
+          },
+          "predicate-validator" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.validator.PredicateValidatorDefinition"
+          }
+        }
+      }
+    },
+    "properties" : {
+      "beans" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.BeansDeserializer"
+      },
+      "error-handler" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer"
+      },
+      "errorHandler" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer"
+      },
+      "from" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer"
+      },
+      "on-exception" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.OnExceptionDefinition"
+      },
+      "onException" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.OnExceptionDefinition"
+      },
+      "route" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.RouteDefinition"
+      },
+      "route-template" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.RouteTemplateDefinition"
+      },
+      "routeTemplate" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.RouteTemplateDefinition"
+      },
+      "templated-route" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.TemplatedRouteDefinition"
+      },
+      "templatedRoute" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.TemplatedRouteDefinition"
+      },
+      "rest" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestDefinition"
+      }
+    }
+  }
+}

--- a/camel-route-support/src/main/resources/io/kaoto/backend/api/service/deployment/generator/camelroute/integration.json
+++ b/camel-route-support/src/main/resources/io/kaoto/backend/api/service/deployment/generator/camelroute/integration.json
@@ -1,0 +1,7297 @@
+{
+  "description": "Integration is the Schema for the integrations API",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "Integration"
+      ]
+    },
+    "metadata": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "clusterName": {
+          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "creationTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsType": {
+                "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsV1": {
+                "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "manager": {
+                "description": "Manager is an identifier of the workflow managing these fields.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "operation": {
+                "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subresource": {
+                "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "time": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "apiVersion",
+              "kind",
+              "name",
+              "uid"
+            ],
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "controller": {
+                "description": "If true, this reference points to the managing controller.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                "type": "string"
+              }
+            },
+            "x-kubernetes-map-type": "atomic"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "selfLink": {
+          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "spec": {
+      "description": "IntegrationSpec defines the desired state of Integration",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "configuration": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "ConfigurationSpec --",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "resourceKey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "resourceMountPoint": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "resourceType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "dependencies": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "flows": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "Flow is an unstructured object representing a Camel Flow in YAML/JSON DSL",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "integrationKit": {
+          "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "kit": {
+          "description": "Deprecated: use the IntegrationKit field",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "profile": {
+          "description": "TraitProfile represents lists of traits that are enabled for the specific installation/integration",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replicas": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "repositories": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "resources": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "ResourceSpec --",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "compression": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "content": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentKey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentRef": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "mountPath": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rawContent": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "byte"
+              },
+              "type": {
+                "description": "ResourceType --",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "serviceAccountName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sources": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "SourceSpec --",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "compression": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "content": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentKey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentRef": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interceptors": {
+                "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "language": {
+                "description": "Language --",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "loader": {
+                "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "property-names": {
+                "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "rawContent": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "byte"
+              },
+              "type": {
+                "description": "Type defines the kind of source described by this object",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "template": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "spec": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "required": [
+                "containers"
+              ],
+              "properties": {
+                "activeDeadlineSeconds": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "int64"
+                },
+                "containers": {
+                  "type": "array",
+                  "items": {
+                    "description": "A single application container that you want to run within a pod.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "fieldRef": {
+                                  "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "configMapRef": {
+                              "description": "The ConfigMap to select from",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "secretRef": {
+                              "description": "The Secret to select from",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "lifecycle": {
+                        "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "livenessProbe": {
+                        "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "containerPort"
+                          ],
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "hostIP": {
+                              "description": "What host IP to bind the external port to.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "hostPort": {
+                              "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "resources": {
+                        "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        }
+                      },
+                      "securityContext": {
+                        "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "capabilities": {
+                            "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "add": {
+                                "description": "Added capabilities",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "properties": {
+                            "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "dnsPolicy": {
+                  "description": "DNSPolicy defines how a pod's DNS will be configured.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "ephemeralContainers": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "fieldRef": {
+                                  "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "configMapRef": {
+                              "description": "The ConfigMap to select from",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "secretRef": {
+                              "description": "The Secret to select from",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "lifecycle": {
+                        "description": "Lifecycle is not allowed for ephemeral containers.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "livenessProbe": {
+                        "description": "Probes are not allowed for ephemeral containers.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "Ports are not allowed for ephemeral containers.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "containerPort"
+                          ],
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "hostIP": {
+                              "description": "What host IP to bind the external port to.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "hostPort": {
+                              "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "readinessProbe": {
+                        "description": "Probes are not allowed for ephemeral containers.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "resources": {
+                        "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        }
+                      },
+                      "securityContext": {
+                        "description": "SecurityContext is not allowed for ephemeral containers.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "capabilities": {
+                            "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "add": {
+                                "description": "Added capabilities",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "startupProbe": {
+                        "description": "Probes are not allowed for ephemeral containers.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "targetContainerName": {
+                        "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "properties": {
+                            "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "initContainers": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "A single application container that you want to run within a pod.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "fieldRef": {
+                                  "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "configMapRef": {
+                              "description": "The ConfigMap to select from",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "secretRef": {
+                              "description": "The Secret to select from",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "lifecycle": {
+                        "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "livenessProbe": {
+                        "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "containerPort"
+                          ],
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "hostIP": {
+                              "description": "What host IP to bind the external port to.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "hostPort": {
+                              "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "resources": {
+                        "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        }
+                      },
+                      "securityContext": {
+                        "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "capabilities": {
+                            "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "add": {
+                                "description": "Added capabilities",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "exec": {
+                            "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies the http request to perform.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "port"
+                            ],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "properties": {
+                            "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "nodeSelector": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "restartPolicy": {
+                  "description": "RestartPolicy describes how the container should be restarted. Only one of the following restart policies may be specified. If none of the following policies is specified, the default one is RestartPolicyAlways.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "terminationGracePeriodSeconds": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "int64"
+                },
+                "topologySpreadConstraints": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "maxSkew",
+                      "topologyKey",
+                      "whenUnsatisfiable"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "maxSkew": {
+                        "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "topologyKey": {
+                        "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assigment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "volumes": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "partition": {
+                            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeID": {
+                            "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "azureDisk": {
+                        "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "properties": {
+                          "cachingMode": {
+                            "description": "Host Caching mode: None, Read Only, Read Write.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "diskName": {
+                            "description": "The Name of the data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "description": "The URI the data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "kind": {
+                            "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "azureFile": {
+                        "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "properties": {
+                          "readOnly": {
+                            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretName": {
+                            "description": "the name of secret that contains Azure Storage Account Name and Key",
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "description": "Share Name",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cephfs": {
+                        "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "monitors"
+                        ],
+                        "properties": {
+                          "monitors": {
+                            "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "path": {
+                            "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretFile": {
+                            "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "secretRef": {
+                            "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "user": {
+                            "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "cinder": {
+                        "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretRef": {
+                            "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "volumeID": {
+                            "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "configMap": {
+                        "description": "ConfigMap represents a configMap that should populate this volume",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "The key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its keys must be defined",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "csi": {
+                        "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "nodePublishSecretRef": {
+                            "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "readOnly": {
+                            "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeAttributes": {
+                            "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "downwardAPI": {
+                        "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "Items is a list of downward API volume file",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "emptyDir": {
+                        "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "medium": {
+                            "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "sizeLimit": {
+                            "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      },
+                      "ephemeral": {
+                        "description": "Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "readOnly": {
+                            "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "spec"
+                            ],
+                            "properties": {
+                              "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ]
+                              },
+                              "spec": {
+                                "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                                "type": "object",
+                                "properties": {
+                                  "accessModes": {
+                                    "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "dataSource": {
+                                    "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) * An existing custom resource that implements data population (Alpha) In order to use custom resource types that implement data population, the AnyVolumeDataSource feature gate must be enabled. If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "limits": {
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      },
+                                      "requests": {
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "selector": {
+                                    "description": "A label query over volumes to consider for binding.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "storageClassName": {
+                                    "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "volumeName": {
+                                    "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "fc": {
+                        "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lun": {
+                            "description": "Optional: FC target lun number",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "targetWWNs": {
+                            "description": "Optional: FC target worldwide names (WWNs)",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "wwids": {
+                            "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "flexVolume": {
+                        "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "Driver is the name of the driver to use for this volume.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "options": {
+                            "description": "Optional: Extra command options if any.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "readOnly": {
+                            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretRef": {
+                            "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "flocker": {
+                        "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "datasetName": {
+                            "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "datasetUUID": {
+                            "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "gcePersistentDisk": {
+                        "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "pdName"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "partition": {
+                            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "pdName": {
+                            "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "gitRepo": {
+                        "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "repository"
+                        ],
+                        "properties": {
+                          "directory": {
+                            "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "repository": {
+                            "description": "Repository URL",
+                            "type": "string"
+                          },
+                          "revision": {
+                            "description": "Commit hash for the specified revision.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "glusterfs": {
+                        "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "properties": {
+                          "endpoints": {
+                            "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "hostPath": {
+                        "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "path"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "iscsi": {
+                        "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "description": "whether support iSCSI Discovery CHAP authentication",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "chapAuthSession": {
+                            "description": "whether support iSCSI Session CHAP authentication",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "fsType": {
+                            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "initiatorName": {
+                            "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "iqn": {
+                            "description": "Target iSCSI Qualified Name.",
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lun": {
+                            "description": "iSCSI Target Lun number.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "portals": {
+                            "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretRef": {
+                            "description": "CHAP Secret for iSCSI target and initiator authentication",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "targetPortal": {
+                            "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "server": {
+                            "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "claimName"
+                        ],
+                        "properties": {
+                          "claimName": {
+                            "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "photonPersistentDisk": {
+                        "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "pdID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "pdID": {
+                            "description": "ID that identifies Photon Controller persistent disk",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "portworxVolume": {
+                        "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeID": {
+                            "description": "VolumeID uniquely identifies a Portworx volume",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "projected": {
+                        "description": "Items for all in one resources secrets, configmaps, and downward API",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "list of volume projections",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMap": {
+                                  "description": "information about the configMap data to project",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "items": {
+                                      "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": [
+                                              "integer",
+                                              "null"
+                                            ],
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its keys must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "downwardAPI": {
+                                  "description": "information about the downwardAPI data to project",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": [
+                                              "integer",
+                                              "null"
+                                            ],
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "divisor": {
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "secret": {
+                                  "description": "information about the secret data to project",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "items": {
+                                      "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": [
+                                              "integer",
+                                              "null"
+                                            ],
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "serviceAccountToken": {
+                                  "description": "information about the serviceAccountToken data to project",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "quobyte": {
+                        "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "properties": {
+                          "group": {
+                            "description": "Group to map volume access to Default is no group",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "registry": {
+                            "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "user": {
+                            "description": "User to map volume access to Defaults to serivceaccount user",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "volume": {
+                            "description": "Volume is a string that references an already created Quobyte volume by name.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "rbd": {
+                        "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "image": {
+                            "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "monitors": {
+                            "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "pool": {
+                            "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretRef": {
+                            "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "user": {
+                            "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "scaleIO": {
+                        "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "gateway": {
+                            "description": "The host address of the ScaleIO API Gateway.",
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretRef": {
+                            "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "sslEnabled": {
+                            "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "storageMode": {
+                            "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "storagePool": {
+                            "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "system": {
+                            "description": "The name of the storage system as configured in ScaleIO.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "secret": {
+                        "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "The key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its keys must be defined",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretName": {
+                            "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "storageos": {
+                        "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "readOnly": {
+                            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "secretRef": {
+                            "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "volumeName": {
+                            "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "volumeNamespace": {
+                            "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "vsphereVolume": {
+                        "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "volumePath"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "storagePolicyID": {
+                            "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "storagePolicyName": {
+                            "description": "Storage Policy Based Management (SPBM) profile name.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "volumePath": {
+                            "description": "Path that identifies vSphere volume vmdk",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "traits": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "description": "A TraitSpec contains the configuration of a trait",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "configuration"
+            ],
+            "properties": {
+              "configuration": {
+                "description": "TraitConfiguration --",
+                "x-kubernetes-preserve-unknown-fields": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "IntegrationStatus defines the observed state of Integration",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "capabilities": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "conditions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "IntegrationCondition describes the state of a resource at a certain point.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "firstTruthyTime": {
+                "description": "First time the condition status transitioned to True.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of integration condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "configuration": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "ConfigurationSpec --",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "resourceKey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "resourceMountPoint": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "resourceType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "dependencies": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "digest": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generatedResources": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "ResourceSpec --",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "compression": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "content": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentKey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentRef": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "mountPath": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rawContent": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "byte"
+              },
+              "type": {
+                "description": "ResourceType --",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "generatedSources": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "SourceSpec --",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "compression": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "content": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentKey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentRef": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interceptors": {
+                "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "language": {
+                "description": "Language --",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "loader": {
+                "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "property-names": {
+                "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "rawContent": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "byte"
+              },
+              "type": {
+                "description": "Type defines the kind of source described by this object",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "image": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "integrationKit": {
+          "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "kit": {
+          "description": "Deprecated: use the IntegrationKit field",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lastInitTimestamp": {
+          "description": "The timestamp representing the last time when this integration was initialized.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "phase": {
+          "description": "IntegrationPhase --",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "platform": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "profile": {
+          "description": "TraitProfile represents lists of traits that are enabled for the specific installation/integration",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replicas": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "runtimeProvider": {
+          "description": "RuntimeProvider --",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runtimeVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "selector": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "camel.apache.org",
+      "kind": "Integration",
+      "version": "v1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletBindingDeploymentGeneratorService.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.kaoto.backend.api.service.deployment.generator.DeploymentGeneratorService;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletBindingStepParserService;
+import io.kaoto.backend.metadata.parser.step.camelroute.CamelRouteFileProcessor;
 import io.kaoto.backend.model.deployment.Deployment;
 import io.kaoto.backend.model.deployment.kamelet.KameletBinding;
 import io.kaoto.backend.model.deployment.kamelet.KameletBindingSpec;
@@ -23,6 +24,7 @@ import org.yaml.snakeyaml.constructor.Constructor;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,6 +58,18 @@ public class KameletBindingDeploymentGeneratorService
         return "Kamelet Bindings are used to create simple integrations that "
                 + "link a start step to an end step with optional "
                 + "intermediate action steps.";
+    }
+
+    @Override
+    public String validationSchema() {
+        try {
+            String schema = new String(CamelRouteFileProcessor.class
+                    .getResourceAsStream("kameletbinding.json").readAllBytes());
+            return schema;
+        } catch (IOException e) {
+            log.error("Can't load Kamelet Binding DSL schema", e);
+        }
+        return "";
     }
 
     @Override

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletDeploymentGeneratorService.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.kaoto.backend.api.service.deployment.generator.DeploymentGeneratorService;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletStepParserService;
+import io.kaoto.backend.metadata.parser.step.camelroute.CamelRouteFileProcessor;
 import io.kaoto.backend.model.deployment.Deployment;
 import io.kaoto.backend.model.deployment.kamelet.Kamelet;
 import io.kaoto.backend.model.parameter.Parameter;
@@ -20,6 +21,7 @@ import org.yaml.snakeyaml.representer.Representer;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -55,6 +57,18 @@ public class KameletDeploymentGeneratorService implements DeploymentGeneratorSer
     public String description() {
         return "A Kamelet is a snippet of a route. It defines meta building "
                 + "blocks or steps that can be reused on integrations.";
+    }
+
+    @Override
+    public String validationSchema() {
+        try {
+            String schema = new String(CamelRouteFileProcessor.class
+                    .getResourceAsStream("kamelet.json").readAllBytes());
+            return schema;
+        } catch (IOException e) {
+            log.error("Can't load Kamelet DSL schema", e);
+        }
+        return "";
     }
 
     @Override

--- a/kamelet-support/src/main/resources/io/kaoto/backend/metadata/parser/step/camelroute/kamelet-dsl.json
+++ b/kamelet-support/src/main/resources/io/kaoto/backend/metadata/parser/step/camelroute/kamelet-dsl.json
@@ -1,0 +1,473 @@
+{
+  "description": "Kamelet is the Schema for the kamelets API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "the desired specification",
+      "properties": {
+        "definition": {
+          "description": "defines the formal configuration of the Kamelet",
+          "properties": {
+            "$schema": {
+              "description": "JSONSchemaURL represents a schema url.",
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "example": {
+              "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "externalDocs": {
+              "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "properties": {
+              "additionalProperties": {
+                "properties": {
+                  "default": {
+                    "description": "default is a default value for undefined object fields.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "enum": {
+                    "items": {
+                      "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "type": "array"
+                  },
+                  "example": {
+                    "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "exclusiveMaximum": {
+                    "type": "boolean"
+                  },
+                  "exclusiveMinimum": {
+                    "type": "boolean"
+                  },
+                  "format": {
+                    "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF\" following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,255)\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "maxItems": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "maxLength": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "maxProperties": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "maximum": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": "string"
+                  },
+                  "minItems": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "minLength": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "minProperties": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "minimum": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": "string"
+                  },
+                  "multipleOf": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": "string"
+                  },
+                  "nullable": {
+                    "type": "boolean"
+                  },
+                  "pattern": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "uniqueItems": {
+                    "type": "boolean"
+                  },
+                  "x-descriptors": {
+                    "description": "XDescriptors is a list of extended properties that trigger a custom behavior in external systems",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "dependencies": {
+          "description": "Camel dependencies needed by the Kamelet",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sources": {
+          "description": "sources in any Camel DSL supported",
+          "items": {
+            "description": "SourceSpec defines the configuration for one or more routes to be executed in a certain Camel DSL language",
+            "properties": {
+              "compression": {
+                "description": "if the content is compressed (base64 encrypted)",
+                "type": "boolean"
+              },
+              "content": {
+                "description": "the source code (plain text)",
+                "type": "string"
+              },
+              "contentKey": {
+                "description": "the confimap key holding the source content",
+                "type": "string"
+              },
+              "contentRef": {
+                "description": "the confimap reference holding the source content",
+                "type": "string"
+              },
+              "contentType": {
+                "description": "the content type (tipically text or binary)",
+                "type": "string"
+              },
+              "interceptors": {
+                "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "language": {
+                "description": "specify which is the language (Camel DSL) used to interpret this source code",
+                "type": "string"
+              },
+              "loader": {
+                "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                "type": "string"
+              },
+              "name": {
+                "description": "the name of the specification",
+                "type": "string"
+              },
+              "path": {
+                "description": "the path where the file is stored",
+                "type": "string"
+              },
+              "property-names": {
+                "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "rawContent": {
+                "description": "the source code (binary)",
+                "format": "byte",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type defines the kind of source described by this object",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "template": {
+          "description": "the main source in YAML DSL",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "types": {
+          "additionalProperties": {
+            "description": "EventTypeSpec represents a specification for an event type",
+            "properties": {
+              "mediaType": {
+                "description": "media type as expected for HTTP media types (ie, application/json)",
+                "type": "string"
+              },
+              "schema": {
+                "description": "the expected schema for the event",
+                "properties": {
+                  "$schema": {
+                    "description": "JSONSchemaURL represents a schema url.",
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "example": {
+                    "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "externalDocs": {
+                    "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "additionalProperties": {
+                      "properties": {
+                        "default": {
+                          "description": "default is a default value for undefined object fields.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "enum": {
+                          "items": {
+                            "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "type": "array"
+                        },
+                        "example": {
+                          "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "exclusiveMaximum": {
+                          "type": "boolean"
+                        },
+                        "exclusiveMinimum": {
+                          "type": "boolean"
+                        },
+                        "format": {
+                          "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF\" following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,255)\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "maxItems": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "maxLength": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "maxProperties": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "maximum": {
+                          "description": "A Number represents a JSON number literal.",
+                          "type": "string"
+                        },
+                        "minItems": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "minLength": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "minProperties": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "minimum": {
+                          "description": "A Number represents a JSON number literal.",
+                          "type": "string"
+                        },
+                        "multipleOf": {
+                          "description": "A Number represents a JSON number literal.",
+                          "type": "string"
+                        },
+                        "nullable": {
+                          "type": "boolean"
+                        },
+                        "pattern": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "uniqueItems": {
+                          "type": "boolean"
+                        },
+                        "x-descriptors": {
+                          "description": "XDescriptors is a list of extended properties that trigger a custom behavior in external systems",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "required": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "description": "data specification types for the events consumed/produced by the Kamelet",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "the actual status of the resource",
+      "properties": {
+        "conditions": {
+          "description": "Conditions --",
+          "items": {
+            "description": "KameletCondition describes the state of a resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of kamelet condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the most recent generation observed for this Kamelet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase --",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties --",
+          "items": {
+            "description": "KameletProperty specify the behavior of a property in a Kamelet",
+            "properties": {
+              "default": {
+                "description": "the default value of the property (if any)",
+                "type": "string"
+              },
+              "name": {
+                "description": "the name of the property",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/kamelet-support/src/main/resources/io/kaoto/backend/metadata/parser/step/camelroute/kamelet.json
+++ b/kamelet-support/src/main/resources/io/kaoto/backend/metadata/parser/step/camelroute/kamelet.json
@@ -1,0 +1,1033 @@
+{
+  "description": "Kamelet is the Schema for the kamelets API",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "Kamelet"
+      ]
+    },
+    "metadata": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "clusterName": {
+          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "creationTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsType": {
+                "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsV1": {
+                "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "manager": {
+                "description": "Manager is an identifier of the workflow managing these fields.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "operation": {
+                "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subresource": {
+                "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "time": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "apiVersion",
+              "kind",
+              "name",
+              "uid"
+            ],
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "controller": {
+                "description": "If true, this reference points to the managing controller.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                "type": "string"
+              }
+            },
+            "x-kubernetes-map-type": "atomic"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "selfLink": {
+          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "spec": {
+      "description": "KameletSpec defines the desired state of Kamelet",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "authorization": {
+          "description": "AuthorizationSpec is TODO (oauth information)",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "definition": {
+          "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "$schema": {
+              "description": "JSONSchemaURL represents a schema url.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "example": {
+              "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "externalDocs": {
+              "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "properties": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "default": {
+                    "description": "default is a default value for undefined object fields.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "enum": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                      "x-kubernetes-preserve-unknown-fields": true
+                    }
+                  },
+                  "example": {
+                    "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "exclusiveMaximum": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "exclusiveMinimum": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "format": {
+                    "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxItems": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int64"
+                  },
+                  "maxLength": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int64"
+                  },
+                  "maxProperties": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int64"
+                  },
+                  "maximum": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "minItems": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int64"
+                  },
+                  "minLength": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int64"
+                  },
+                  "minProperties": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int64"
+                  },
+                  "minimum": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "multipleOf": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nullable": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pattern": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "uniqueItems": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "x-descriptors": {
+                    "description": "The list of descriptors that determine which UI components to use on different views",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "required": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "dependencies": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "flow": {
+          "description": "Deprecated: use template",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "sources": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "SourceSpec --",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "compression": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "content": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentKey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentRef": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contentType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interceptors": {
+                "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "language": {
+                "description": "Language --",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "loader": {
+                "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "property-names": {
+                "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "rawContent": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "byte"
+              },
+              "type": {
+                "description": "Type defines the kind of source described by this object",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "template": {
+          "description": "Template is an unstructured object representing a Kamelet template in YAML/JSON DSL",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "types": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "mediaType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "schema": {
+                "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "$schema": {
+                    "description": "JSONSchemaURL represents a schema url.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "example": {
+                    "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "externalDocs": {
+                    "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "url": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "properties": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "default": {
+                          "description": "default is a default value for undefined object fields.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "enum": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          }
+                        },
+                        "example": {
+                          "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "exclusiveMaximum": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "exclusiveMinimum": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "format": {
+                          "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "maxItems": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int64"
+                        },
+                        "maxLength": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int64"
+                        },
+                        "maxProperties": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int64"
+                        },
+                        "maximum": {
+                          "description": "A Number represents a JSON number literal.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "minItems": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int64"
+                        },
+                        "minLength": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int64"
+                        },
+                        "minProperties": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int64"
+                        },
+                        "minimum": {
+                          "description": "A Number represents a JSON number literal.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "multipleOf": {
+                          "description": "A Number represents a JSON number literal.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "nullable": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "pattern": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "title": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "uniqueItems": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "x-descriptors": {
+                          "description": "The list of descriptors that determine which UI components to use on different views",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "KameletStatus defines the observed state of Kamelet",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "conditions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "KameletCondition describes the state of a resource at a certain point.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of kamelet condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "phase": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "properties": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "default": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "camel.apache.org",
+      "kind": "Kamelet",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/kamelet-support/src/main/resources/io/kaoto/backend/metadata/parser/step/camelroute/kameletbinding.json
+++ b/kamelet-support/src/main/resources/io/kaoto/backend/metadata/parser/step/camelroute/kameletbinding.json
@@ -1,0 +1,7974 @@
+{
+  "description": "KameletBinding is the Schema for the kamelets binding API",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KameletBinding"
+      ]
+    },
+    "metadata": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "clusterName": {
+          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "creationTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsType": {
+                "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsV1": {
+                "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "manager": {
+                "description": "Manager is an identifier of the workflow managing these fields.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "operation": {
+                "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subresource": {
+                "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "time": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "apiVersion",
+              "kind",
+              "name",
+              "uid"
+            ],
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "controller": {
+                "description": "If true, this reference points to the managing controller.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                "type": "string"
+              }
+            },
+            "x-kubernetes-map-type": "atomic"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "selfLink": {
+          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "spec": {
+      "description": "KameletBindingSpec --",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "errorHandler": {
+          "description": "ErrorHandler is an optional handler called upon an error occuring in the integration",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "integration": {
+          "description": "Integration is an optional integration used to specify custom parameters",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "configuration": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "ConfigurationSpec --",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "resourceKey": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "resourceMountPoint": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "resourceType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "dependencies": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "flows": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "Flow is an unstructured object representing a Camel Flow in YAML/JSON DSL",
+                "x-kubernetes-preserve-unknown-fields": true
+              }
+            },
+            "integrationKit": {
+              "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "kit": {
+              "description": "Deprecated: use the IntegrationKit field",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "profile": {
+              "description": "TraitProfile represents lists of traits that are enabled for the specific installation/integration",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replicas": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "repositories": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "resources": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "ResourceSpec --",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "compression": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "content": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentKey": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentRef": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mountPath": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "path": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rawContent": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "byte"
+                  },
+                  "type": {
+                    "description": "ResourceType --",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "serviceAccountName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sources": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "SourceSpec --",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "compression": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "content": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentKey": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentRef": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interceptors": {
+                    "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "language": {
+                    "description": "Language --",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "loader": {
+                    "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "path": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "property-names": {
+                    "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "rawContent": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "byte"
+                  },
+                  "type": {
+                    "description": "Type defines the kind of source described by this object",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "template": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "spec": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "required": [
+                    "containers"
+                  ],
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "format": "int64"
+                    },
+                    "containers": {
+                      "type": "array",
+                      "items": {
+                        "description": "A single application container that you want to run within a pod.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "args": {
+                            "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "description": "List of environment variables to set in the container. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "EnvVar represents an environment variable present in a Container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "name"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "description": "Selects a key of a ConfigMap.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key to select.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the ConfigMap or its key must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "fieldRef": {
+                                      "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "fieldPath"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "description": "Path of the field to select in the specified API version.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "resourceFieldRef": {
+                                      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "resource"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "description": "Container name: required for volumes, optional for env vars",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "description": "Required: resource to select",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "secretKeyRef": {
+                                      "description": "Selects a key of a secret in the pod's namespace",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the Secret or its key must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "envFrom": {
+                            "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "description": "The ConfigMap to select from",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "prefix": {
+                                  "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "description": "The Secret to select from",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "image": {
+                            "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies the http request to perform.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "preStop": {
+                                "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies the http request to perform.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "livenessProbe": {
+                            "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "name": {
+                            "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                            "type": "string"
+                          },
+                          "ports": {
+                            "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "ContainerPort represents a network port in a single container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "containerPort"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "hostIP": {
+                                  "description": "What host IP to bind the external port to.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "name": {
+                                  "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "containerPort",
+                              "protocol"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "readinessProbe": {
+                            "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "resources": {
+                            "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          },
+                          "securityContext": {
+                            "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "description": "Added capabilities",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "Capability represent POSIX capabilities type",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "description": "Removed capabilities",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "Capability represent POSIX capabilities type",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "privileged": {
+                                "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "runAsNonRoot": {
+                                "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "seLinuxOptions": {
+                                "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "description": "Level is SELinux level label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "description": "Role is a SELinux role label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "description": "Type is a SELinux type label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "description": "User is a SELinux user label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "seccompProfile": {
+                                "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "windowsOptions": {
+                                "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "startupProbe": {
+                            "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "stdin": {
+                            "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "description": "volumeDevices is the list of block devices to be used by the container.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "devicePath",
+                                "name"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "volumeMounts": {
+                            "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "VolumeMount describes a mounting of a Volume within a container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "mountPath",
+                                "name"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "description": "This must match the Name of a Volume.",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "workingDir": {
+                            "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "dnsPolicy": {
+                      "description": "DNSPolicy defines how a pod's DNS will be configured.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "ephemeralContainers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "description": "An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "args": {
+                            "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "description": "List of environment variables to set in the container. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "EnvVar represents an environment variable present in a Container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "name"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "description": "Selects a key of a ConfigMap.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key to select.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the ConfigMap or its key must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "fieldRef": {
+                                      "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "fieldPath"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "description": "Path of the field to select in the specified API version.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "resourceFieldRef": {
+                                      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "resource"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "description": "Container name: required for volumes, optional for env vars",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "description": "Required: resource to select",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "secretKeyRef": {
+                                      "description": "Selects a key of a secret in the pod's namespace",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the Secret or its key must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "envFrom": {
+                            "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "description": "The ConfigMap to select from",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "prefix": {
+                                  "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "description": "The Secret to select from",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "image": {
+                            "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "description": "Lifecycle is not allowed for ephemeral containers.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies the http request to perform.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "preStop": {
+                                "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies the http request to perform.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "livenessProbe": {
+                            "description": "Probes are not allowed for ephemeral containers.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "name": {
+                            "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+                            "type": "string"
+                          },
+                          "ports": {
+                            "description": "Ports are not allowed for ephemeral containers.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "ContainerPort represents a network port in a single container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "containerPort"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "hostIP": {
+                                  "description": "What host IP to bind the external port to.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "name": {
+                                  "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "readinessProbe": {
+                            "description": "Probes are not allowed for ephemeral containers.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "resources": {
+                            "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          },
+                          "securityContext": {
+                            "description": "SecurityContext is not allowed for ephemeral containers.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "description": "Added capabilities",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "Capability represent POSIX capabilities type",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "description": "Removed capabilities",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "Capability represent POSIX capabilities type",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "privileged": {
+                                "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "runAsNonRoot": {
+                                "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "seLinuxOptions": {
+                                "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "description": "Level is SELinux level label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "description": "Role is a SELinux role label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "description": "Type is a SELinux type label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "description": "User is a SELinux user label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "seccompProfile": {
+                                "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "windowsOptions": {
+                                "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "startupProbe": {
+                            "description": "Probes are not allowed for ephemeral containers.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "stdin": {
+                            "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "targetContainerName": {
+                            "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "description": "volumeDevices is the list of block devices to be used by the container.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "devicePath",
+                                "name"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "volumeMounts": {
+                            "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "VolumeMount describes a mounting of a Volume within a container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "mountPath",
+                                "name"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "description": "This must match the Name of a Volume.",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "workingDir": {
+                            "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "initContainers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "description": "A single application container that you want to run within a pod.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "args": {
+                            "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "description": "List of environment variables to set in the container. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "EnvVar represents an environment variable present in a Container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "name"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "description": "Selects a key of a ConfigMap.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key to select.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the ConfigMap or its key must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "fieldRef": {
+                                      "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "fieldPath"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "description": "Path of the field to select in the specified API version.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "resourceFieldRef": {
+                                      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "resource"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "description": "Container name: required for volumes, optional for env vars",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "description": "Required: resource to select",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "secretKeyRef": {
+                                      "description": "Selects a key of a secret in the pod's namespace",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the Secret or its key must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "envFrom": {
+                            "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "description": "The ConfigMap to select from",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "prefix": {
+                                  "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "description": "The Secret to select from",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret must be defined",
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "image": {
+                            "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies the http request to perform.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "preStop": {
+                                "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "description": "HTTPGet specifies the http request to perform.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "The header field name",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "The header field value",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "Path to access on the HTTP server.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "livenessProbe": {
+                            "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "name": {
+                            "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                            "type": "string"
+                          },
+                          "ports": {
+                            "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "ContainerPort represents a network port in a single container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "containerPort"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "hostIP": {
+                                  "description": "What host IP to bind the external port to.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "name": {
+                                  "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "containerPort",
+                              "protocol"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "readinessProbe": {
+                            "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "resources": {
+                            "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          },
+                          "securityContext": {
+                            "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "description": "Added capabilities",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "Capability represent POSIX capabilities type",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "description": "Removed capabilities",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "Capability represent POSIX capabilities type",
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "privileged": {
+                                "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "runAsNonRoot": {
+                                "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "seLinuxOptions": {
+                                "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "description": "Level is SELinux level label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "description": "Role is a SELinux role label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "description": "Type is a SELinux type label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "description": "User is a SELinux user label that applies to the container.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "seccompProfile": {
+                                "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "windowsOptions": {
+                                "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "startupProbe": {
+                            "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "httpGet": {
+                                "description": "HTTPGet specifies the http request to perform.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "periodSeconds": {
+                                "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "successThreshold": {
+                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "port"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "timeoutSeconds": {
+                                "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "stdin": {
+                            "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "description": "volumeDevices is the list of block devices to be used by the container.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "devicePath",
+                                "name"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "volumeMounts": {
+                            "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "VolumeMount describes a mounting of a Volume within a container.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "mountPath",
+                                "name"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "description": "This must match the Name of a Volume.",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "workingDir": {
+                            "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "nodeSelector": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "restartPolicy": {
+                      "description": "RestartPolicy describes how the container should be restarted. Only one of the following restart policies may be specified. If none of the following policies is specified, the default one is RestartPolicyAlways.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "format": "int64"
+                    },
+                    "topologySpreadConstraints": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "maxSkew",
+                          "topologyKey",
+                          "whenUnsatisfiable"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "maxSkew": {
+                            "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "topologyKey": {
+                            "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assigment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "volumes": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "volumeID"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "partition": {
+                                "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "readOnly": {
+                                "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeID": {
+                                "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "azureDisk": {
+                            "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "diskName",
+                              "diskURI"
+                            ],
+                            "properties": {
+                              "cachingMode": {
+                                "description": "Host Caching mode: None, Read Only, Read Write.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "diskName": {
+                                "description": "The Name of the data disk in the blob storage",
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "description": "The URI the data disk in the blob storage",
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "kind": {
+                                "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "azureFile": {
+                            "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "secretName",
+                              "shareName"
+                            ],
+                            "properties": {
+                              "readOnly": {
+                                "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretName": {
+                                "description": "the name of secret that contains Azure Storage Account Name and Key",
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "description": "Share Name",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "cephfs": {
+                            "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "monitors"
+                            ],
+                            "properties": {
+                              "monitors": {
+                                "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                "type": "array",
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "path": {
+                                "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretFile": {
+                                "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "user": {
+                                "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "cinder": {
+                            "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "volumeID"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "volumeID": {
+                                "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "configMap": {
+                            "description": "ConfigMap represents a configMap that should populate this volume",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "items": {
+                                "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Maps a string key to a path within a volume.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key",
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to project.",
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
+                                      "format": "int32"
+                                    },
+                                    "path": {
+                                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its keys must be defined",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "csi": {
+                            "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "driver"
+                            ],
+                            "properties": {
+                              "driver": {
+                                "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "nodePublishSecretRef": {
+                                "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "readOnly": {
+                                "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeAttributes": {
+                                "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "downwardAPI": {
+                            "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "items": {
+                                "description": "Items is a list of downward API volume file",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "fieldRef": {
+                                      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "fieldPath"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "description": "Path of the field to select in the specified API version.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "mode": {
+                                      "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
+                                      "format": "int32"
+                                    },
+                                    "path": {
+                                      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "resource"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "description": "Container name: required for volumes, optional for env vars",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "description": "Required: resource to select",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "emptyDir": {
+                            "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "medium": {
+                                "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "sizeLimit": {
+                                "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "ephemeral": {
+                            "description": "Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "readOnly": {
+                                "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeClaimTemplate": {
+                                "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "spec"
+                                ],
+                                "properties": {
+                                  "metadata": {
+                                    "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ]
+                                  },
+                                  "spec": {
+                                    "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                                    "type": "object",
+                                    "properties": {
+                                      "accessModes": {
+                                        "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "dataSource": {
+                                        "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) * An existing custom resource that implements data population (Alpha) In order to use custom resource types that implement data population, the AnyVolumeDataSource feature gate must be enabled. If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "required": [
+                                          "kind",
+                                          "name"
+                                        ],
+                                        "properties": {
+                                          "apiGroup": {
+                                            "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "kind": {
+                                            "description": "Kind is the type of resource being referenced",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of resource being referenced",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "resources": {
+                                        "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "limits": {
+                                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          },
+                                          "requests": {
+                                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "selector": {
+                                        "description": "A label query over volumes to consider for binding.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "storageClassName": {
+                                        "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "volumeMode": {
+                                        "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "volumeName": {
+                                        "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "fc": {
+                            "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "lun": {
+                                "description": "Optional: FC target lun number",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "readOnly": {
+                                "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "targetWWNs": {
+                                "description": "Optional: FC target worldwide names (WWNs)",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "wwids": {
+                                "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "flexVolume": {
+                            "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "driver"
+                            ],
+                            "properties": {
+                              "driver": {
+                                "description": "Driver is the name of the driver to use for this volume.",
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "options": {
+                                "description": "Optional: Extra command options if any.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "readOnly": {
+                                "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "flocker": {
+                            "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "datasetName": {
+                                "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "datasetUUID": {
+                                "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "gcePersistentDisk": {
+                            "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "pdName"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "partition": {
+                                "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "pdName": {
+                                "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "gitRepo": {
+                            "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "repository"
+                            ],
+                            "properties": {
+                              "directory": {
+                                "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "repository": {
+                                "description": "Repository URL",
+                                "type": "string"
+                              },
+                              "revision": {
+                                "description": "Commit hash for the specified revision.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "glusterfs": {
+                            "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "endpoints",
+                              "path"
+                            ],
+                            "properties": {
+                              "endpoints": {
+                                "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "hostPath": {
+                            "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "path"
+                            ],
+                            "properties": {
+                              "path": {
+                                "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "iscsi": {
+                            "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "iqn",
+                              "lun",
+                              "targetPortal"
+                            ],
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "description": "whether support iSCSI Discovery CHAP authentication",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "chapAuthSession": {
+                                "description": "whether support iSCSI Session CHAP authentication",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "initiatorName": {
+                                "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "iqn": {
+                                "description": "Target iSCSI Qualified Name.",
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "lun": {
+                                "description": "iSCSI Target Lun number.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "portals": {
+                                "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "description": "CHAP Secret for iSCSI target and initiator authentication",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "targetPortal": {
+                                "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "name": {
+                            "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "path",
+                              "server"
+                            ],
+                            "properties": {
+                              "path": {
+                                "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "server": {
+                                "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "persistentVolumeClaim": {
+                            "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "claimName"
+                            ],
+                            "properties": {
+                              "claimName": {
+                                "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "photonPersistentDisk": {
+                            "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "pdID"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "pdID": {
+                                "description": "ID that identifies Photon Controller persistent disk",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "portworxVolume": {
+                            "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "volumeID"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeID": {
+                                "description": "VolumeID uniquely identifies a Portworx volume",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "projected": {
+                            "description": "Items for all in one resources secrets, configmaps, and downward API",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "sources": {
+                                "description": "list of volume projections",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Projection that may be projected along with other supported volume types",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMap": {
+                                      "description": "information about the configMap data to project",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "required": [
+                                              "key",
+                                              "path"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "description": "The key to project.",
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "format": "int32"
+                                              },
+                                              "path": {
+                                                "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the ConfigMap or its keys must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "downwardAPI": {
+                                      "description": "information about the downwardAPI data to project",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "description": "Items is a list of DownwardAPIVolume file",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "required": [
+                                              "path"
+                                            ],
+                                            "properties": {
+                                              "fieldRef": {
+                                                "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                "type": [
+                                                  "object",
+                                                  "null"
+                                                ],
+                                                "required": [
+                                                  "fieldPath"
+                                                ],
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "fieldPath": {
+                                                    "description": "Path of the field to select in the specified API version.",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "mode": {
+                                                "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "format": "int32"
+                                              },
+                                              "path": {
+                                                "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                "type": [
+                                                  "object",
+                                                  "null"
+                                                ],
+                                                "required": [
+                                                  "resource"
+                                                ],
+                                                "properties": {
+                                                  "containerName": {
+                                                    "description": "Container name: required for volumes, optional for env vars",
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "divisor": {
+                                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "description": "Required: resource to select",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "secret": {
+                                      "description": "information about the secret data to project",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "required": [
+                                              "key",
+                                              "path"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "description": "The key to project.",
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "format": "int32"
+                                              },
+                                              "path": {
+                                                "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "description": "Specify whether the Secret or its key must be defined",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "serviceAccountToken": {
+                                      "description": "information about the serviceAccountToken data to project",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "path"
+                                      ],
+                                      "properties": {
+                                        "audience": {
+                                          "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "expirationSeconds": {
+                                          "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "format": "int64"
+                                        },
+                                        "path": {
+                                          "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "quobyte": {
+                            "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "registry",
+                              "volume"
+                            ],
+                            "properties": {
+                              "group": {
+                                "description": "Group to map volume access to Default is no group",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "registry": {
+                                "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "user": {
+                                "description": "User to map volume access to Defaults to serivceaccount user",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volume": {
+                                "description": "Volume is a string that references an already created Quobyte volume by name.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "rbd": {
+                            "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "image",
+                              "monitors"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "image": {
+                                "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "monitors": {
+                                "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                "type": "array",
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "pool": {
+                                "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "user": {
+                                "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "scaleIO": {
+                            "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "gateway",
+                              "secretRef",
+                              "system"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "gateway": {
+                                "description": "The host address of the ScaleIO API Gateway.",
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "sslEnabled": {
+                                "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "storageMode": {
+                                "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePool": {
+                                "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "system": {
+                                "description": "The name of the storage system as configured in ScaleIO.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "secret": {
+                            "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int32"
+                              },
+                              "items": {
+                                "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "Maps a string key to a path within a volume.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "key",
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to project.",
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ],
+                                      "format": "int32"
+                                    },
+                                    "path": {
+                                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its keys must be defined",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretName": {
+                                "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "storageos": {
+                            "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumeNamespace": {
+                                "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "vsphereVolume": {
+                            "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "volumePath"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePolicyID": {
+                                "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePolicyName": {
+                                "description": "Storage Policy Based Management (SPBM) profile name.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumePath": {
+                                "description": "Path that identifies vSphere volume vmdk",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "traits": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "description": "A TraitSpec contains the configuration of a trait",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "configuration"
+                ],
+                "properties": {
+                  "configuration": {
+                    "description": "TraitConfiguration --",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas for the binding",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "sink": {
+          "description": "Sink is the destination of the integration defined by this binding",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "properties": {
+              "description": "Properties are a key value representation of endpoint properties",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "ref": {
+              "description": "Ref can be used to declare a Kubernetes resource as source/sink endpoint",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "types": {
+              "description": "Types defines the schema of the data produced/consumed by the endpoint",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "mediaType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "schema": {
+                    "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "$schema": {
+                        "description": "JSONSchemaURL represents a schema url.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "example": {
+                        "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "externalDocs": {
+                        "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "description": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "properties": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "default": {
+                              "description": "default is a default value for undefined object fields.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "enum": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "example": {
+                              "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "exclusiveMaximum": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "exclusiveMinimum": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "format": {
+                              "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "maxItems": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "maxLength": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "maxProperties": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "maximum": {
+                              "description": "A Number represents a JSON number literal.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "minItems": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "minLength": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "minProperties": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "minimum": {
+                              "description": "A Number represents a JSON number literal.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "multipleOf": {
+                              "description": "A Number represents a JSON number literal.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "nullable": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "pattern": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "title": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uniqueItems": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "x-descriptors": {
+                              "description": "The list of descriptors that determine which UI components to use on different views",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "title": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "type": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "uri": {
+              "description": "URI can alternatively be used to specify the (Camel) endpoint explicitly",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "source": {
+          "description": "Source is the starting point of the integration defined by this binding",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "properties": {
+              "description": "Properties are a key value representation of endpoint properties",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "ref": {
+              "description": "Ref can be used to declare a Kubernetes resource as source/sink endpoint",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "types": {
+              "description": "Types defines the schema of the data produced/consumed by the endpoint",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "mediaType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "schema": {
+                    "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "$schema": {
+                        "description": "JSONSchemaURL represents a schema url.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "example": {
+                        "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "externalDocs": {
+                        "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "description": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "properties": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "default": {
+                              "description": "default is a default value for undefined object fields.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "enum": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "example": {
+                              "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "exclusiveMaximum": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "exclusiveMinimum": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "format": {
+                              "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "maxItems": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "maxLength": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "maxProperties": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "maximum": {
+                              "description": "A Number represents a JSON number literal.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "minItems": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "minLength": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "minProperties": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "format": "int64"
+                            },
+                            "minimum": {
+                              "description": "A Number represents a JSON number literal.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "multipleOf": {
+                              "description": "A Number represents a JSON number literal.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "nullable": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "pattern": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "title": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uniqueItems": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "x-descriptors": {
+                              "description": "The list of descriptors that determine which UI components to use on different views",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "title": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "type": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "uri": {
+              "description": "URI can alternatively be used to specify the (Camel) endpoint explicitly",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "steps": {
+          "description": "Steps contains an optional list of intermediate steps that are executed between the Source and the Sink",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "Endpoint represents a source/sink external entity",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "properties": {
+                "description": "Properties are a key value representation of endpoint properties",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "ref": {
+                "description": "Ref can be used to declare a Kubernetes resource as source/sink endpoint",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "types": {
+                "description": "Types defines the schema of the data produced/consumed by the endpoint",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "mediaType": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "schema": {
+                      "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "$schema": {
+                          "description": "JSONSchemaURL represents a schema url.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "example": {
+                          "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "externalDocs": {
+                          "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "url": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "properties": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "default is a default value for undefined object fields.",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "description": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "enum": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "example": {
+                                "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "exclusiveMaximum": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "exclusiveMinimum": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "format": {
+                                "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "maxItems": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "maxLength": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "maxProperties": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "maximum": {
+                                "description": "A Number represents a JSON number literal.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "minItems": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "minLength": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "minProperties": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
+                                "format": "int64"
+                              },
+                              "minimum": {
+                                "description": "A Number represents a JSON number literal.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "multipleOf": {
+                                "description": "A Number represents a JSON number literal.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "nullable": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "pattern": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "title": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "uniqueItems": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "x-descriptors": {
+                                "description": "The list of descriptors that determine which UI components to use on different views",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "required": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "title": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "uri": {
+                "description": "URI can alternatively be used to specify the (Camel) endpoint explicitly",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "KameletBindingStatus --",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "conditions": {
+          "description": "Conditions --",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "KameletBindingCondition describes the state of a resource at a certain point.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of kameletBinding condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "phase": {
+          "description": "Phase --",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replicas": {
+          "description": "Replicas is the number of actual replicas of the binding",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "selector": {
+          "description": "Selector allows to identify pods belonging to the binding",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "camel.apache.org",
+      "kind": "KameletBinding",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/services-interfaces/src/main/java/io/kaoto/backend/api/service/deployment/generator/DeploymentGeneratorService.java
+++ b/services-interfaces/src/main/java/io/kaoto/backend/api/service/deployment/generator/DeploymentGeneratorService.java
@@ -37,6 +37,14 @@ public interface DeploymentGeneratorService {
     String description();
 
     /*
+     * 🐱 method description: String
+     *
+     * Returns validationSchema/validationSchema URL if exists.
+
+     */
+    String validationSchema();
+
+    /*
      * 🐱method parse: String
      * 🐱param steps: List[Step]
      * 🐱param parameters: List[Parameter]


### PR DESCRIPTION
This is still WIP, the main idea is to provide validation schema under `/capabilities/{dsl-name}/schema` that can be injected by monaco-yaml plugin for client site validation. 

Unfortunately currently we have schemas only for camel-yaml dsl .. my kamelet schema included here isn't working. 