### PR TITLE
Switch back to Quarkus 2.14.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <!-- Quarkus version -->
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.15.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.14.3.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
 
         <!-- SonarCloud analysis -->


### PR DESCRIPTION
to avoid failure on Windows CI

Signed-off-by: Aurélien Pupier <apupier@redhat.com>