### PR TITLE
fix(steps): Details for some steps are not shown

### DIFF
--- a/api/src/test/java/io/kaoto/backend/api/resource/v1/StepResourceIT.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v1/StepResourceIT.java
@@ -1,16 +1,14 @@
 package io.kaoto.backend.api.resource.v1;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.assertj.core.api.Condition;
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.kaoto.backend.model.step.Step;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusIntegrationTest
 class StepResourceIT {
@@ -36,5 +34,16 @@ class StepResourceIT {
                 .haveAtLeast(10, weHaveKamelets)
                 .haveAtLeast(10, weHaveEIPs);
     }
-    
+
+    @Test
+    void checkAllRequiredPropertiesInitialized() throws Exception {
+        ValidatableResponse response = RestAssured.given().get("/v1/steps").then().statusCode(200);
+
+        String json = response.extract().body().asString();
+        ObjectMapper objectMapper = new ObjectMapper();
+        Step[] steps = objectMapper.readValue(json, Step[].class);
+
+        assertThat(steps)
+                .allMatch(step -> step.getRequired() != null);
+    }
 }

--- a/model/src/main/java/io/kaoto/backend/model/step/Step.java
+++ b/model/src/main/java/io/kaoto/backend/model/step/Step.java
@@ -36,7 +36,7 @@ public class Step extends Metadata {
     @JsonView(Views.Complete.class)
     private List<Parameter> parameters;
     @JsonView(Views.Complete.class)
-    private List<String> required;
+    private List<String> required = new LinkedList<>();
     @JsonView(Views.Complete.class)
     private List<Branch> branches;
     @JsonView(Views.Summary.class)
@@ -143,7 +143,9 @@ public class Step extends Metadata {
     }
 
     public void setRequired(final List<String> required) {
-        this.required = required;
+        if (required != null) {
+            this.required = required;
+        }
     }
 
     /*


### PR DESCRIPTION
The UI requires that the `required` property from Stepto be of an array type.

This commit adds a default value of an empty array for those steps that don't have any required property.

fixes [KaotoUI #1231](https://github.com/KaotoIO/kaoto-ui/issues/1231)