### PR TITLE
feature: Add step ids, if they exist (camel routes)

### DIFF
--- a/api/src/test/resources/io/kaoto/backend/api/resource/eip.kamelet.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/eip.kamelet.yaml
@@ -25,12 +25,18 @@ spec:
           copy: true
           steps:
           - saga:
-              completion:
-                uri: direct:completion
               propagation: MANDATORY
+              completion-mode: MANUAL
               compensation:
                 uri: direct:compensation
-              completion-mode: MANUAL
+              completion:
+                uri: direct:completion
+              option:
+              - key: o1
+                simple: ${body}
+              - key: o2
+                expression:
+                  simple: ${body}
               steps:
               - throttle:
                   constant: '5'
@@ -39,19 +45,13 @@ spec:
                   caller-runs-when-rejected: false
                   reject-execution: false
               - sample:
+                  sample-period: '1500'
+                  message-frequency: 5
                   description:
                     text: Message Sampler
                     lang: eng
-                  sample-period: '1500'
-                  message-frequency: 5
               - script:
                   groovy: some groovy script
-              option:
-              - key: o1
-                simple: ${body}
-              - key: o2
-                expression:
-                  simple: ${body}
           - delay:
               expression:
                 simple: ${body}
@@ -95,8 +95,8 @@ spec:
                 parallel-processing: true
                 stop-on-exception: true
             - remove-headers:
-                exclude-pattern: toExclude
                 pattern: toRemove
+                exclude-pattern: toExclude
             - resequence:
                 simple: ${in.header.seqnum}
                 stream-config:
@@ -106,8 +106,8 @@ spec:
                 - transform:
                     simple: baz
                 - remove-properties:
-                    exclude-pattern: toExclude
                     pattern: toRemove
+                    exclude-pattern: toExclude
             - aggregate:
                 correlation-expression:
                   simple: ${header.StockSymbol}
@@ -143,8 +143,8 @@ spec:
                 mark-rollback-only: true
                 message: test
             - throw-exception:
-                exception-type: java.lang.IllegalArgumentException
                 message: test
+                exception-type: java.lang.IllegalArgumentException
             - stop: {}
       - filter:
           simple: '{{?foo}}'
@@ -168,8 +168,8 @@ spec:
                   parameters:
                     accessToken: '{{accessToken}}'
               - multicast:
-                  stop-on-exception: true
                   parallel-processing: true
+                  stop-on-exception: true
                   steps:
                   - process:
                       ref: '{{myProcessor}}'

--- a/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
+++ b/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
@@ -1,25 +1,23 @@
 package io.kaoto.backend.api.service.step.parser.camelroute;
 
+import io.kaoto.backend.api.metadata.catalog.StepCatalog;
+import io.kaoto.backend.api.service.deployment.generator.camelroute.CamelRouteDeploymentGeneratorService;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import javax.inject.Inject;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
-import io.kaoto.backend.api.metadata.catalog.StepCatalog;
-import io.kaoto.backend.api.service.deployment.generator.camelroute.CamelRouteDeploymentGeneratorService;
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
 class CamelRouteStepParserServiceTest {
@@ -69,7 +67,8 @@ class CamelRouteStepParserServiceTest {
 
 
     @ParameterizedTest
-    @ValueSource(strings = {"route.yaml", "route2-complex-expressions.yaml", "route3-complex-expressions.yaml"})
+    @ValueSource(strings = {"route.yaml", "route2-complex-expressions.yaml",
+            "route3-complex-expressions.yaml", "route-ids.yaml"})
     void deepParseParametrized(String file) throws IOException {
         var route = new String(this.getClass().getResourceAsStream(file).readAllBytes(),
                 StandardCharsets.UTF_8);
@@ -83,7 +82,6 @@ class CamelRouteStepParserServiceTest {
         var yaml = camelRouteDeploymentGeneratorService.parse(steps.getSteps(), steps.getMetadata(),
                 steps.getParameters());
         assertThat(yaml).isEqualToNormalizingNewlines(route);
-        assertTrue(camelRouteDeploymentGeneratorService.supportedCustomResources().isEmpty());
     }
 
 

--- a/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route-ids.yaml
+++ b/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route-ids.yaml
@@ -1,0 +1,16 @@
+- from:
+    id: from-74c5
+    uri: file:data
+    parameters:
+      noop: 'true'
+    steps:
+    - log:
+        id: log-5f36
+        message: ${body}
+    - dynamic-router:
+        id: dynamic-router-32
+        simple: ${body}
+    - set-header:
+        id: set-header-23245
+        simple: foo
+        name: bar

--- a/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
@@ -298,7 +298,7 @@ public class KamelPopulator {
                     if (p.isPath()) {
                         uri.append(p.getPathSeparator());
                         uri.append(value != null ? value : p.getDefaultValue());
-                    } else if (value != null) {
+                    } else if (value != null && !p.getId().equalsIgnoreCase("step-id-kaoto")) {
                         params.put(p.getId(), value.toString());
                     }
                 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
@@ -271,8 +271,10 @@ public class KamelPopulator {
                 HashMap<String, String> params = buildUri(s, uri);
                 from.setUri(uri.toString());
                 from.setParameters(params);
+                from.setId(s.getStepId());
             } else {
-                from.getSteps().add(processStep(s, true));
+                final var flowStep = processStep(s, true);
+                from.getSteps().add(flowStep);
             }
         }
 
@@ -507,6 +509,7 @@ public class KamelPopulator {
                 expression.setExpression((Expression) p.getValue());
             }
         }
+        expression.setId(step.getStepId());
         return expression;
     }
 
@@ -565,7 +568,7 @@ public class KamelPopulator {
     private FlowStep getCamelConnector(final Step step, final boolean to) {
         var uri = new StringBuilder(step.getName());
         var params = buildUri(step, uri);
-        FlowStep flowStep = new UriFlowStep(uri.toString(), params);
+        FlowStep flowStep = new UriFlowStep(uri.toString(), params, null);
         if (to) {
             flowStep = new ToFlowStep(flowStep);
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletRepresenter.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/kamelet/KameletRepresenter.java
@@ -236,6 +236,8 @@ public class KameletRepresenter extends Representer {
                         properties.put(URI, step.getUri());
                     }
                     if (step.getParameters() != null && !step.getParameters().isEmpty()) {
+                        //remove step-id-kaoto, it is not a real property
+                        step.getParameters().remove("step-kaoto-id");
                         properties.put(PARAMETERS, step.getParameters());
                     }
                     if (step.getProperties() != null && !step.getProperties().isEmpty()) {

--- a/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessor.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessor.java
@@ -96,9 +96,15 @@ public class CamelRouteFileProcessor extends JsonProcessFile<Step> {
         step.setTitle(parsedCamelJson.title());
         step.setDescription(parsedCamelJson.description());
         step.setGroup(parsedCamelJson.group());
-        step.setParameters(parsedCamelJson.parameters());
         step.setRequired(parsedCamelJson.required());
         step.setType(parsedCamelJson.type());
+        step.setParameters(parsedCamelJson.parameters());
+        //Add extra step-id parameter
+        final var stepId = new StringParameter();
+        step.getParameters().add(stepId);
+        stepId.setTitle("Step ID");
+        stepId.setId("step-id-kaoto");
+        stepId.setDescription("Identifier of this step inside the route.");
 
         return step;
     }

--- a/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletFileProcessor.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/metadata/parser/step/kamelet/KameletFileProcessor.java
@@ -139,6 +139,15 @@ public class KameletFileProcessor extends YamlProcessFile<Step> {
             step.getParameters().add(p);
 
         }
+
+        if (step.getKind().startsWith("EIP")) {
+            //Add extra step-id parameter to EIP like steps
+            final var stepId = new StringParameter();
+            step.getParameters().add(stepId);
+            stepId.setTitle("Step ID");
+            stepId.setId("step-id-kaoto");
+            stepId.setDescription("Identifier of this step inside the route.");
+        }
     }
 
     private Parameter getParameter(final KameletDefinitionProperty property,

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Expression.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Expression.java
@@ -8,7 +8,6 @@ import io.kaoto.backend.model.deployment.kamelet.step.EIPStep;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 @JsonPropertyOrder({"name", "constant", "simple", "jq", "jsonpath"})
@@ -50,7 +49,8 @@ public class Expression extends EIPStep {
             final @JsonProperty(NAME_LABEL) String name,
             final @JsonProperty(RESULT_TYPE) String resultType,
             final @JsonProperty(RESULT_TYPE2) String resultType2,
-            final @JsonProperty(JSON_PATH_LABEL) Object jsonpath) {
+            final @JsonProperty(JSON_PATH_LABEL) Object jsonpath,
+            final @JsonProperty("id") String id) {
         setExpression(expression);
         setConstant(constant);
         setSimple(simple);
@@ -58,6 +58,7 @@ public class Expression extends EIPStep {
         setName(name);
         setResultType(resultType != null ? resultType : resultType2);
         setJsonpath(jsonpath);
+        setId(id);
     }
 
     public Expression(Step step) {
@@ -76,6 +77,7 @@ public class Expression extends EIPStep {
             setName(e.getName());
             setJsonpath(e.getJsonpath());
             setExpression(e.getExpression());
+            setId(e.getId());
         } else if (obj instanceof Map map) {
             setPropertiesFromMap(map, this);
         }
@@ -104,6 +106,9 @@ public class Expression extends EIPStep {
         }
         if (map.containsKey(EXPRESSION_LABEL) && map.get(EXPRESSION_LABEL) != null) {
             expression.setExpression((Expression) map.get(EXPRESSION_LABEL));
+        }
+        if (map.containsKey("id") && map.get("id") != null) {
+            expression.setId(String.valueOf(map.get("id")));
         }
     }
 
@@ -170,7 +175,7 @@ public class Expression extends EIPStep {
     @Override
     public Map<String, Object> getRepresenterProperties() {
 
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getConstant() != null) {
             if (this.getConstant() instanceof CSimple csimple) {
                 properties.put(CONSTANT_LABEL, csimple.getRepresenterProperties());

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Aggregate.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Aggregate.java
@@ -8,7 +8,6 @@ import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -165,7 +164,7 @@ public class Aggregate extends EIPStep {
 
 
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.correlationExpression != null) {
             properties.put(CORRELATION_EXPRESSION, this.correlationExpression);
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/CircuitBreaker.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/CircuitBreaker.java
@@ -54,7 +54,8 @@ public class CircuitBreaker extends EIPStep {
             final @JsonProperty(RESILIENCE_4_J_CONFIGURATION_LABEL) Map<String, String>  resilience4jConfiguration,
             final @JsonProperty(FAULT_TOLERANCE_CONFIGURATION_LABEL) Map<String, String>  faultToleranceConfiguration,
             final @JsonProperty(CONFIGURATION_LABEL) String configuration,
-            final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
+            final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+            final @JsonProperty("id") String id) {
         super();
         setSteps(steps);
         setOnFallback(onFallback);
@@ -62,6 +63,7 @@ public class CircuitBreaker extends EIPStep {
         setFaultToleranceConfiguration(faultToleranceConfiguration);
         setConfiguration(configuration);
         setDescription(description);
+        setId(id);
     }
 
     public CircuitBreaker(final Step step, final KamelPopulator kameletPopulator) {
@@ -80,7 +82,7 @@ public class CircuitBreaker extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
 
         if (this.resilience4jConfiguration != null) {
             properties.put(RESILIENCE_4_J_CONFIGURATION_LABEL2, this.getResilience4jConfiguration());

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ClaimCheck.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ClaimCheck.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -47,7 +46,7 @@ public class ClaimCheck extends EIPStep {
     }
 
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.operation != null) {
             properties.put(OPERATION_LABEL, this.operation);
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ConvertBodyTo.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ConvertBodyTo.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -37,7 +36,7 @@ public class ConvertBodyTo extends EIPStep {
     }
 
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.type != null) {
             properties.put(TYPE_LABEL, this.type);
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Delay.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Delay.java
@@ -5,7 +5,6 @@ import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -72,7 +71,7 @@ public class Delay extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.expression != null) {
             properties.put(EXPRESSION_LABEL, this.expression);
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/EIPStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/EIPStep.java
@@ -1,6 +1,7 @@
 package io.kaoto.backend.model.deployment.kamelet.step;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
@@ -12,6 +13,7 @@ import io.kaoto.backend.model.step.Step;
 import org.jboss.logging.Logger;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +22,10 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class EIPStep implements Serializable {
     protected static final Logger log = Logger.getLogger(EIPStep.class);
+
+    //All steps have ids
+    @JsonProperty("id")
+    private String id;
 
     protected EIPStep() {
         //Needed for serialization
@@ -36,6 +42,13 @@ public abstract class EIPStep implements Serializable {
                     }
                 }
             }
+        }
+        setId(step.getStepId());
+    }
+
+    public EIPStep(Map<String, Object> map) {
+        if(map.containsKey("id")) {
+            this.setId(String.valueOf(map.get("id")));
         }
     }
 
@@ -58,6 +71,7 @@ public abstract class EIPStep implements Serializable {
                     log.error("Couldn't assign value to parameter " + parameter.getId(), e);
                 }
             }
+            step.setStepId(this.getId());
             processBranches(res.get(), catalog, kameletStepParserService);
         }
 
@@ -87,4 +101,20 @@ public abstract class EIPStep implements Serializable {
     protected abstract void assignProperty(final Parameter parameter);
 
     public abstract Map<String, Object> getRepresenterProperties();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    protected Map<String, Object> getDefaultRepresenterProperties() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        if(this.getId() != null) {
+            map.put("id", this.getId());
+        }
+        return map;
+    }
 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Enrich.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Enrich.java
@@ -5,7 +5,6 @@ import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -70,7 +69,7 @@ public class Enrich extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.expression != null) {
             properties.put(EXPRESSION_LABEL, this.expression);
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Filter.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Filter.java
@@ -8,7 +8,6 @@ import io.kaoto.backend.model.deployment.kamelet.FlowStep;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +62,7 @@ public class Filter extends EIPStep implements ConditionBlock {
     }
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getSimple() != null) {
             properties.put(SIMPLE_LABEL, this.getSimple());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/From.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/From.java
@@ -8,15 +8,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresenter;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 
 @JsonPropertyOrder({"steps"})
-@JsonDeserialize(
-        using = JsonDeserializer.None.class
-)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class From extends UriFlowStep {
     private static final long serialVersionUID = -4601560033032557024L;
@@ -35,11 +32,7 @@ public class From extends UriFlowStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(KameletRepresenter.URI, this.getUri());
-        if (this.getParameters() != null && !this.getParameters().isEmpty()) {
-            properties.put(KameletRepresenter.PARAMETERS, this.getParameters());
-        }
+        Map<String, Object> properties = super.getRepresenterProperties();
         properties.put(KameletRepresenter.STEPS, this.getSteps());
         return properties;
     }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/IdempotentConsumer.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/IdempotentConsumer.java
@@ -73,9 +73,10 @@ public class IdempotentConsumer extends Expression {
                        final @JsonProperty(SKIP_DUPLICATE_LABEL2) Boolean skipDuplicate2,
                        final @JsonProperty(REMOVE_ON_FAILURE_LABEL) Boolean removeOnFailure,
                        final @JsonProperty(REMOVE_ON_FAILURE_LABEL2) Boolean removeOnFailure2,
-                       final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
+                       final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+                       final @JsonProperty("id") String id) {
 
-        super(expression, constant, simple, jq, null, null, null, null);
+        super(expression, constant, simple, jq, null, null, null, null, id);
         setIdempotentRepository(idempotentRepository != null ? idempotentRepository : idempotentRepository2);
         setEager(eager);
         setCompletionEager(completionEager != null ? completionEager : completionEager2);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/LoadBalanceFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/LoadBalanceFlowStep.java
@@ -81,7 +81,9 @@ public class LoadBalanceFlowStep implements FlowStep {
 
     protected void assignParameters(final Step res) {
         for (var param : res.getParameters()) {
-            param.setValue(this.getProperties());
+            if (!param.getId().equalsIgnoreCase("step-id-kaoto")) {
+                param.setValue(this.getProperties());
+            }
         }
     }
 

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/LogStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/LogStep.java
@@ -1,10 +1,10 @@
 package io.kaoto.backend.model.deployment.kamelet.step;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -20,10 +20,8 @@ public class LogStep extends EIPStep {
 
     private String message;
 
-    @JsonProperty(LOGGING_LEVEL)
     private String loggingLevel;
 
-    @JsonProperty(LOG_NAME)
     private String logName;
     private String marker;
     private String logger;
@@ -32,11 +30,31 @@ public class LogStep extends EIPStep {
     public LogStep() {
     }
 
+    @JsonCreator
+    public LogStep(final @JsonProperty(MESSAGE) String message,
+                final @JsonProperty(MARKER) String marker,
+                final @JsonProperty(LOGGER) String logger,
+                final @JsonProperty(DESCRIPTION) String description,
+                final @JsonProperty(LOGGING_LEVEL) String loggingLevel,
+                final @JsonProperty(LOG_NAME) String logName,
+                final @JsonProperty(LOGGING_LEVEL1) String loggingLevel2,
+                final @JsonProperty(LOG_NAME1) String logName2,
+                final @JsonProperty("id") String id) {
+        setMessage(message);
+        setMarker(marker);
+        setLogger(logger);
+        setDescription(description);
+        setLoggingLevel(loggingLevel != null ? loggingLevel : loggingLevel2);
+        setLogName(logName != null ? logName : logName2);
+        setId(id);
+    }
+
     public LogStep(Step step) {
         super(step);
     }
 
     public LogStep(Map<String, Object> map) {
+        super(map);
         if (map.containsKey(MESSAGE)) {
             this.setMessage(String.valueOf(map.get(MESSAGE)));
         }
@@ -63,7 +81,7 @@ public class LogStep extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.message != null) {
             properties.put(MESSAGE, this.getMessage());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Loop.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Loop.java
@@ -66,8 +66,9 @@ public class Loop extends Expression {
                               final @JsonProperty(BREAK_ON_SHUTDOWN_LABEL2) Boolean breakOnShutdown2,
                               final @JsonProperty(DISABLED_LABEL) Boolean disabled,
                               final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
-                              final @JsonProperty(STEPS_LABEL) List<FlowStep> steps) {
-        super(expression, constant, simple, jq, null, null, null, null);
+                              final @JsonProperty(STEPS_LABEL) List<FlowStep> steps,
+                              final @JsonProperty("id") String id) {
+        super(expression, constant, simple, jq, null, null, null, null, id);
         setCopy(copy);
         setDoWhile(doWhile != null ? doWhile : doWhile2);
         setBreakOnShutdown(breakOnShutdown != null ? breakOnShutdown : breakOnShutdown2);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Multicast.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Multicast.java
@@ -9,7 +9,6 @@ import io.kaoto.backend.model.deployment.kamelet.FlowStep;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -103,7 +102,8 @@ public class Multicast extends EIPStep {
                      final @JsonProperty(ON_PREPARE_LABEL) Map<String, Object> onPrepare,
                      final @JsonProperty(ON_PREPARE_LABEL2) Map<String, Object> onPrepare2,
                      final @JsonProperty(SHARE_UNIT_OF_WORK_LABEL) Boolean shareUnitOfWork,
-                     final @JsonProperty(SHARE_UNIT_OF_WORK_LABEL2) Boolean shareUnitOfWork2) {
+                     final @JsonProperty(SHARE_UNIT_OF_WORK_LABEL2) Boolean shareUnitOfWork2,
+                     final @JsonProperty("id") String id) {
         super();
         setDescription(description);
         setSteps(steps);
@@ -120,6 +120,7 @@ public class Multicast extends EIPStep {
         setExecutorService(executorService != null ? executorService : executorService2);
         setOnPrepare(onPrepare != null ? onPrepare : onPrepare2);
         setShareUnitOfWork(shareUnitOfWork != null ? shareUnitOfWork : shareUnitOfWork2);
+        setId(id);
     }
 
     public Multicast() {
@@ -191,7 +192,7 @@ public class Multicast extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getAggregationStrategy() != null) {
             properties.put(AGGREGATION_STRATEGY_LABEL, this.getAggregationStrategy());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Pipeline.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Pipeline.java
@@ -8,7 +8,6 @@ import io.kaoto.backend.model.deployment.kamelet.FlowStep;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,7 +49,7 @@ public class Pipeline extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getSteps() != null) {
             properties.put(STEPS_LABEL, this.getSteps());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Process.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Process.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -25,7 +24,7 @@ public class Process extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getRef() != null) {
             properties.put(REF_LABEL, this.getRef());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RecipientList.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RecipientList.java
@@ -117,8 +117,9 @@ public class RecipientList extends Expression {
                          final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
                          final @JsonProperty(SIMPLE_LABEL) String simple,
                          final @JsonProperty(JQ_LABEL) String jq,
-                         final @JsonProperty(CONSTANT_LABEL) String constant) {
-        super(expression, constant, simple, jq, null, null, null, null);
+                         final @JsonProperty(CONSTANT_LABEL) String constant,
+                         final @JsonProperty("id") String id) {
+        super(expression, constant, simple, jq, null, null, null, null, id);
         setDelimiter(delimiter);
         setParallelProcessing(parallelProcessing != null ? parallelProcessing : parallelProcessing2);
         setStrategyRef(strategyRef != null ? strategyRef : strategyRef2);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RemoveHeaderFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RemoveHeaderFlowStep.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletStepParserService;
-import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
+import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RemoveHeaders.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RemoveHeaders.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -31,10 +30,12 @@ public class RemoveHeaders extends EIPStep {
     public RemoveHeaders(final @JsonProperty(PATTERN_LABEL) String pattern,
                          final @JsonProperty(EXCLUDE_PATTERN_LABEL)  String excludePattern,
                          final @JsonProperty(EXCLUDE_PATTERN_LABEL2) String excludePattern2,
-                         final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
+                         final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+                         final @JsonProperty("id") String id) {
         setPattern(pattern);
         setExcludePattern(excludePattern != null ? excludePattern : excludePattern2);
         setDescription(description);
+        setId(id);
     }
 
     public RemoveHeaders(Step step) {
@@ -43,7 +44,7 @@ public class RemoveHeaders extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getPattern() != null) {
             properties.put(PATTERN_LABEL, this.getPattern());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RemovePropertyFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RemovePropertyFlowStep.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletStepParserService;
-import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
+import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Resequence.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Resequence.java
@@ -53,8 +53,9 @@ public class Resequence extends Expression {
                       final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
                       final @JsonProperty(SIMPLE_LABEL) String simple,
                       final @JsonProperty(JQ_LABEL) String jq,
-                      final @JsonProperty(CONSTANT_LABEL) String constant) {
-        super(expression, constant, simple, jq, null, null, null, null);
+                      final @JsonProperty(CONSTANT_LABEL) String constant,
+                      final @JsonProperty("id") String id) {
+        super(expression, constant, simple, jq, null, null, null, null, id);
         if (resequencerConfig != null) {
             setStreamConfig(resequencerConfig);
         } else if (resequencerConfig2 != null) {

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Rollback.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Rollback.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -33,10 +32,12 @@ public class Rollback extends EIPStep {
                     final @JsonProperty(MARK_ROLLBACK_ONLY_LABEL2) Boolean markRollbackOnly2,
                     final @JsonProperty(MARK_ROLLBACK_ONLY_LAST_LABEL) Boolean markRollbackOnlyLast,
                     final @JsonProperty(MARK_ROLLBACK_ONLY_LAST_LABEL2) Boolean markRollbackOnlyLast2,
-                    final @JsonProperty(MESSAGE_LABEL) String message) {
+                    final @JsonProperty(MESSAGE_LABEL) String message,
+                    final @JsonProperty("id") String id) {
         setMarkRollbackOnly(markRollbackOnly != null ? markRollbackOnly : markRollbackOnly2);
         setMarkRollbackOnlyLast(markRollbackOnlyLast != null ? markRollbackOnlyLast : markRollbackOnlyLast2);
         setMessage(message);
+        setId(id);
     }
     public Rollback(Step step) {
         super(step);
@@ -44,7 +45,7 @@ public class Rollback extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
 
         if (this.getMarkRollbackOnly() != null) {
             properties.put(MARK_ROLLBACK_ONLY_LABEL2, this.getMarkRollbackOnly());

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RoutingSlip.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/RoutingSlip.java
@@ -47,8 +47,9 @@ public class RoutingSlip extends Expression {
                        final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
                        final @JsonProperty(SIMPLE_LABEL) String simple,
                        final @JsonProperty(JQ_LABEL) String jq,
-                       final @JsonProperty(CONSTANT_LABEL) String constant) {
-        super(expression, constant, simple, jq, null, null, null, null);
+                       final @JsonProperty(CONSTANT_LABEL) String constant,
+                       final @JsonProperty("id") String id) {
+        super(expression, constant, simple, jq, null, null, null, null, id);
         setUriDelimiter(uriDelimiter != null ? uriDelimiter : uriDelimiter2);
         setIgnoreInvalidEndpoints(ignoreInvalidEndpoints != null ? ignoreInvalidEndpoints : ignoreInvalidEndpoints2);
         setCacheSize(cacheSize != null ? cacheSize : cacheSize2);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Saga.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Saga.java
@@ -8,7 +8,6 @@ import io.kaoto.backend.model.deployment.kamelet.FlowStep;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -66,7 +65,8 @@ public class Saga extends EIPStep {
                 final @JsonProperty(COMPENSATION_LABEL) Object compensation,
                 final @JsonProperty(COMPLETION_LABEL) Object completion,
                 final @JsonProperty(OPTION_LABEL) Object option,
-                final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
+                final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+                final @JsonProperty("id") String id) {
         setSagaService(sagaService != null ? sagaService : sagaService2);
         setPropagation(propagation);
         setCompletionMode(completionMode != null ? completionMode : completionMode2);
@@ -75,6 +75,7 @@ public class Saga extends EIPStep {
         setCompletion(completion);
         setOption(option);
         setDescription(description);
+        setId(id);
     }
 
 
@@ -163,10 +164,7 @@ public class Saga extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
-        if (this.getSteps() != null) {
-            properties.put(STEPS_LABEL, this.getSteps());
-        }
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getSagaService() != null) {
             properties.put(SAGA_SERVICE_LABEL, this.getSagaService());
         }
@@ -190,6 +188,9 @@ public class Saga extends EIPStep {
         }
         if (this.getDescription() != null) {
             properties.put(DESCRIPTION_LABEL, this.getDescription());
+        }
+        if (this.getSteps() != null) {
+            properties.put(STEPS_LABEL, this.getSteps());
         }
 
         return properties;

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Sample.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Sample.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -33,10 +32,12 @@ public class Sample extends EIPStep {
                   final @JsonProperty(SAMPLE_PERIOD_LABEL2) String samplePeriod2,
                   final @JsonProperty(MESSAGE_FREQUENCY_LABEL)  Long messageFrequency,
                   final @JsonProperty(MESSAGE_FREQUENCY_LABEL2) Long messageFrequency2,
-                  final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
+                  final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+                  final @JsonProperty("id") String id) {
         setDescription(description);
         setSamplePeriod(samplePeriod != null ? samplePeriod : samplePeriod2);
         setMessageFrequency(messageFrequency != null ? messageFrequency : messageFrequency2);
+        setId(id);
     }
 
     public Sample(Step step) {
@@ -45,7 +46,7 @@ public class Sample extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getSamplePeriod() != null) {
             properties.put(SAMPLE_PERIOD_LABEL, this.getSamplePeriod());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ScriptFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ScriptFlowStep.java
@@ -24,8 +24,7 @@ import java.util.Optional;
 public class ScriptFlowStep implements FlowStep {
     public static final String LABEL = "script";
 
-    public ScriptFlowStep(final @JsonProperty(value = "script", required = true)
-                          Script script) {
+    public ScriptFlowStep(final @JsonProperty(value = "script", required = true) Script script) {
         super();
         setScript(script);
     }
@@ -74,5 +73,4 @@ public class ScriptFlowStep implements FlowStep {
 
         return null;
     }
-
 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ServiceCall.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ServiceCall.java
@@ -154,8 +154,9 @@ public class ServiceCall extends Expression {
                                LOAD_BALANCER_CONFIGURATION_LABEL) Map<String, Object> loadBalancerConfiguration,
                        final @JsonProperty(
                                LOAD_BALANCER_CONFIGURATION_LABEL2) Map<String, Object> loadBalancerConfiguration2,
-                       final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
-        super(expression, constant, simple, jq, null, null, null, null);
+                       final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+                       final @JsonProperty("id") String id) {
+        super(expression, constant, simple, jq, null, null, null, null, id);
         setName(name);
         setUri(uri);
         setComponent(component);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetBodyFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetBodyFlowStep.java
@@ -76,6 +76,8 @@ public class SetBodyFlowStep implements FlowStep {
                 } else if (p.getId()
                         .equalsIgnoreCase(KameletStepParserService.JQ)) {
                     p.setValue(this.getSetBody().getJq());
+                } else if (p.getId().equalsIgnoreCase("step-id-kaoto")) {
+                    res.get().setStepId((String) p.getValue());
                 } else {
                     p.setValue(this.getSetBody().getExpression());
                 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetBodyFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetBodyFlowStep.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletStepParserService;
-import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
+import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.step.Step;
 
 import java.io.Serial;

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetExchangePatternFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetExchangePatternFlowStep.java
@@ -54,7 +54,9 @@ public class SetExchangePatternFlowStep implements FlowStep {
 
         if (res.isPresent()) {
             for (Parameter p : res.get().getParameters()) {
-                p.setValue(getExchangePattern());
+                if (!p.getId().equalsIgnoreCase("step-id-kaoto")) {
+                    p.setValue(getExchangePattern());
+                }
             }
         }
 

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetHeaderFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetHeaderFlowStep.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletStepParserService;
-import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
+import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
@@ -19,12 +19,9 @@ import java.util.Optional;
 
 
 @JsonPropertyOrder({"set-header"})
-@JsonDeserialize(
-        using = JsonDeserializer.None.class
-)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class
-SetHeaderFlowStep implements FlowStep {
+public class SetHeaderFlowStep implements FlowStep {
     public static final String SET_HEADER_LABEL = "set-header";
     public static final String SET_HEADER_LABEL2 = "setHeader";
 
@@ -86,6 +83,8 @@ SetHeaderFlowStep implements FlowStep {
                     p.setValue(this.getSetHeaderPairFlowStep().getExpression());
                 }
             }
+
+            res.get().setStepId(this.getSetHeaderPairFlowStep().getId());
 
             return res.get();
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetHeaderFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetHeaderFlowStep.java
@@ -79,6 +79,8 @@ public class SetHeaderFlowStep implements FlowStep {
                 } else if (p.getId()
                         .equalsIgnoreCase(KameletStepParserService.NAME)) {
                     p.setValue(this.getSetHeaderPairFlowStep().getName());
+                } else if (p.getId().equalsIgnoreCase("step-id-kaoto")) {
+                    res.get().setStepId((String) p.getValue());
                 } else {
                     p.setValue(this.getSetHeaderPairFlowStep().getExpression());
                 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetPropertyFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetPropertyFlowStep.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletStepParserService;
-import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
+import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
@@ -85,6 +85,8 @@ public class SetPropertyFlowStep implements FlowStep {
                 } else {
                     p.setValue(this.getSetPropertyPairFlowStep().getExpression());
                 }
+
+                res.get().setStepId(this.getSetPropertyPairFlowStep().getId());
             }
             return res.get();
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetPropertyFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/SetPropertyFlowStep.java
@@ -82,7 +82,9 @@ public class SetPropertyFlowStep implements FlowStep {
                 } else if (p.getId()
                         .equalsIgnoreCase(KameletStepParserService.JQ)) {
                     p.setValue(this.getSetPropertyPairFlowStep().getJq());
-                } else {
+                } else if (p.getId().equalsIgnoreCase("step-id-kaoto")) {
+                    res.get().setStepId((String) p.getValue());
+                }  else {
                     p.setValue(this.getSetPropertyPairFlowStep().getExpression());
                 }
 

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Sort.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Sort.java
@@ -41,8 +41,9 @@ public class Sort extends Expression {
                 final @JsonProperty(COMPARATOR_LABEL) String comparator,
                 final @JsonProperty(COMPARATOR_LABEL2) String comparator2,
                 final @JsonProperty(COMPARATOR_LABEL3) String comparator3,
-                final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
-        super(expression, constant, simple, jq, null, null, null, null);
+                final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+                final @JsonProperty("id") String id) {
+        super(expression, constant, simple, jq, null, null, null, null, id);
         final var alternativeComparator = comparator2 != null ? comparator2 : comparator3;
         setComparator(comparator != null ? comparator : alternativeComparator);
         setDescription(description);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Threads.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Threads.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -93,7 +92,8 @@ public class Threads extends EIPStep {
                    final @JsonProperty(REJECTED_POLICY_LABEL) String rejectedPolicy,
                    final @JsonProperty(REJECTED_POLICY_LABEL2) String rejectedPolicy2,
                    final @JsonProperty(CALLER_RUNS_WHEN_REJECTED_LABEL) String callerRunsWhenRejected,
-                   final @JsonProperty(CALLER_RUNS_WHEN_REJECTED_LABEL2) String callerRunsWhenRejected2) {
+                   final @JsonProperty(CALLER_RUNS_WHEN_REJECTED_LABEL2) String callerRunsWhenRejected2,
+                   final @JsonProperty("id") String id) {
         setDescription(description);
         setExecutorService(executorService != null ? executorService : executorService2);
         setPoolSize(poolSize != null ? poolSize : poolSize2);
@@ -105,6 +105,7 @@ public class Threads extends EIPStep {
         setThreadName(threadName != null ? threadName : threadName2);
         setRejectedPolicy(rejectedPolicy != null ? rejectedPolicy : rejectedPolicy2);
         setCallerRunsWhenRejected(callerRunsWhenRejected != null ? callerRunsWhenRejected : callerRunsWhenRejected2);
+        setId(id);
     }
 
 
@@ -217,7 +218,7 @@ public class Threads extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = super.getDefaultRepresenterProperties();
         if (this.getDescription() != null) {
             properties.put(DESCRIPTION_LABEL, this.getDescription());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Throttle.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Throttle.java
@@ -65,8 +65,9 @@ public class Throttle extends Expression {
                     final @JsonProperty(CALLER_RUNS_WHEN_REJECTED_LABEL2) Boolean callerRunsWhenRejected2,
                     final @JsonProperty(REJECT_EXECUTION_LABEL) Boolean rejectExecution,
                     final @JsonProperty(REJECT_EXECUTION_LABEL2) Boolean rejectExecution2,
-                    final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description) {
-        super(expression, constant, simple, jq, null, null, null, null);
+                    final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
+                    final @JsonProperty("id") String id) {
+        super(expression, constant, simple, jq, null, null, null, null, id);
         setCorrelationExpression(correlationExpression != null ? correlationExpression : correlationExpression2);
         setExecutorService(executorService != null ? executorService : executorService2);
         setTimePeriodMillis(timePeriodMillis != null ? timePeriodMillis : timePeriodMillis2);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ThrowException.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ThrowException.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -28,10 +27,12 @@ public class ThrowException extends EIPStep {
 
     public ThrowException(final @JsonProperty(EXCEPTION_TYPE_LABEL) String exceptionType,
                           final @JsonProperty(EXCEPTION_TYPE_LABEL2) String exceptionType2,
-                          final @JsonProperty(MESSAGE_LABEL) String message) {
+                          final @JsonProperty(MESSAGE_LABEL) String message,
+                          final @JsonProperty("id") String id) {
         super();
         setExceptionType(exceptionType != null ? exceptionType : exceptionType2);
         setMessage(message);
+        setId(id);
     }
 
     @Override
@@ -51,7 +52,7 @@ public class ThrowException extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        var properties = new HashMap<String, Object>();
+        var properties = super.getDefaultRepresenterProperties();
         if (this.getMessage() != null) {
             properties.put(MESSAGE_LABEL, this.getMessage());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ToDynamic.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/ToDynamic.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -60,7 +59,8 @@ public class ToDynamic extends EIPStep {
                      final @JsonProperty(AUTO_START_COMPONENTS_LABEL) Boolean autoStartComponents,
                      final @JsonProperty(AUTO_START_COMPONENTS_LABEL2) Boolean autoStartComponents2,
                      final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
-                     final @JsonProperty(PARAMETERS_LABEL) Map<String, Object> parameters) {
+                     final @JsonProperty(PARAMETERS_LABEL) Map<String, Object> parameters,
+                     final @JsonProperty("id") String id) {
         super();
         setUri(uri);
         setPattern(pattern);
@@ -71,6 +71,7 @@ public class ToDynamic extends EIPStep {
         setAutoStartComponents(autoStartComponents != null ? autoStartComponents : autoStartComponents2);
         setDescription(description);
         setParameters(parameters);
+        setId(id);
     }
 
     @Override
@@ -111,7 +112,7 @@ public class ToDynamic extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        var properties = new LinkedHashMap<String, Object>();
+        var properties = super.getDefaultRepresenterProperties();
         if (this.getUri() != null) {
             properties.put(URI_LABEL, this.getUri());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Transacted.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/Transacted.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -23,9 +22,11 @@ public class Transacted extends EIPStep {
         super(step);
     }
 
-    public Transacted(final @JsonProperty(REF_LABEL) String ref) {
+    public Transacted(final @JsonProperty(REF_LABEL) String ref,
+                      final @JsonProperty("id") String id) {
         super();
         setRef(ref);
+        setId(id);
     }
 
     @Override
@@ -35,7 +36,7 @@ public class Transacted extends EIPStep {
 
     @Override
     public Map<String, Object> getRepresenterProperties() {
-        var properties = new HashMap<String, Object>();
+        var properties = super.getDefaultRepresenterProperties();
         if (this.getRef() != null) {
             properties.put(REF_LABEL, this.getRef());
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/TransformFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/TransformFlowStep.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.service.step.parser.kamelet.KameletStepParserService;
-import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
+import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
 

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/TryCatch.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/TryCatch.java
@@ -41,11 +41,13 @@ public class TryCatch extends EIPStep {
             final @JsonProperty(DO_CATCH_LABEL) List<DoCatch> doCatch,
             final @JsonProperty(DO_CATCH_LABEL2) List<DoCatch> doCatch2,
             final @JsonProperty(DO_FINALLY_LABEL) GenericFlowWithSteps doFinally,
-            final @JsonProperty(DO_FINALLY_LABEL2) GenericFlowWithSteps doFinally2) {
+            final @JsonProperty(DO_FINALLY_LABEL2) GenericFlowWithSteps doFinally2,
+            final @JsonProperty("id") String id) {
         super();
         setSteps(steps);
         setDoCatch(doCatch != null ? doCatch : doCatch2);
         setDoFinally(doFinally != null ? doFinally : doFinally2);
+        setId(id);
     }
 
     public TryCatch(final Step step, final KamelPopulator kameletPopulator) {

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/UriFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/UriFlowStep.java
@@ -78,8 +78,10 @@ public class UriFlowStep implements FlowStep {
     public Map<String, Object> getRepresenterProperties() {
         Map<String, Object> properties = new HashMap<>();
         properties.put(KameletRepresenter.URI, this.getUri());
-        if (this.getParameters() != null
-                && !this.getParameters().isEmpty()) {
+
+        if (this.getParameters() != null && !this.getParameters().isEmpty()) {
+            //remove step-id-kaoto, it is not a real property
+            this.getParameters().remove("step-kaoto-id");
             properties.put(KameletRepresenter.PARAMETERS, this.getParameters());
         }
         if (this.getId() != null) {

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/UriFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/UriFlowStep.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
@@ -18,30 +17,35 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-@JsonPropertyOrder({"uri", "parameters"})
-@JsonDeserialize(
-        using = JsonDeserializer.None.class
-)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UriFlowStep implements FlowStep {
     @Serial
     private static final long serialVersionUID = 3379417696583645440L;
+    public static final String ID = "id";
+    public static final String PARAMETERS = "parameters";
+    public static final String URI = "uri";
 
     @JsonCreator
     public UriFlowStep(
-            final @JsonProperty(value = "uri") String uri,
-            final @JsonProperty(value = "parameters") Map<String, String> parameters) {
+            final @JsonProperty(value = URI) String uri,
+            final @JsonProperty(value = PARAMETERS) Map<String, String> parameters,
+            final @JsonProperty(value = ID) String id) {
         super();
         setUri(uri);
         setParameters(parameters);
+        setId(id);
     }
 
-    @JsonProperty("uri")
+    @JsonProperty(URI)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String uri;
 
-    @JsonProperty("parameters")
+    @JsonProperty(PARAMETERS)
     private Map<String, String> parameters;
+
+    @JsonProperty(ID)
+    private String id;
 
     public UriFlowStep() {
     }
@@ -62,6 +66,14 @@ public class UriFlowStep implements FlowStep {
         this.uri = uri;
     }
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     @Override
     public Map<String, Object> getRepresenterProperties() {
         Map<String, Object> properties = new HashMap<>();
@@ -69,6 +81,9 @@ public class UriFlowStep implements FlowStep {
         if (this.getParameters() != null
                 && !this.getParameters().isEmpty()) {
             properties.put(KameletRepresenter.PARAMETERS, this.getParameters());
+        }
+        if (this.getId() != null) {
+            properties.put(ID, this.getId());
         }
         return properties;
     }
@@ -130,6 +145,7 @@ public class UriFlowStep implements FlowStep {
         if (res.isPresent() && this.getUri() != null) {
             kameletStepParserService.setValuesOnParameters(res.get(), this.getUri());
             kameletStepParserService.setValuesOnParameters(res.get(), this.getParameters());
+            res.get().setStepId(id);
         }
 
         return res.orElse(null);

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/WireTap.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/WireTap.java
@@ -95,7 +95,8 @@ public class WireTap extends EIPStep {
                    final @JsonProperty(AUTO_START_COMPONENTS_LABEL) Boolean autoStartComponents,
                    final @JsonProperty(AUTO_START_COMPONENTS_LABEL2) Boolean autoStartComponents2,
                    final @JsonProperty(DESCRIPTION_LABEL) Map<String, String> description,
-                   final @JsonProperty(URI_LABEL) String uri) {
+                   final @JsonProperty(URI_LABEL) String uri,
+                   final @JsonProperty("id") String id) {
         super();
         setCopy(copy);
         setDynamicUri(dynamicUri != null ? dynamicUri : dynamicUri2);
@@ -111,6 +112,7 @@ public class WireTap extends EIPStep {
         setUri(new UriFlowStep());
         getUri().setUri(uri);
         getUri().setParameters(parameters);
+        setId(id);
     }
 
     @Override

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/choice/Choice.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/choice/Choice.java
@@ -3,8 +3,8 @@ package io.kaoto.backend.model.deployment.kamelet.step.choice;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.kaoto.backend.model.deployment.kamelet.step.ConditionBlock;
 import io.kaoto.backend.model.deployment.kamelet.FlowStep;
+import io.kaoto.backend.model.deployment.kamelet.step.ConditionBlock;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessorTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteFileProcessorTest.java
@@ -88,7 +88,9 @@ class CamelRouteFileProcessorTest {
                         "d4", null),
                 "lazyStartProducer", new BooleanParameter(
                         "lazyStartProducer", "Lazy Start Producer",
-                        "d5", false)
+                        "d5", false),
+                "step-id-kaoto", new StringParameter("step-id-kaoto", "Step ID",
+                        "Identifier of this step inside the route.", null, null)
         );
 
         expectedParameterValues.get("name").setPath(true);

--- a/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteParseCatalogTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/metadata/parser/step/camelroute/CamelRouteParseCatalogTest.java
@@ -118,7 +118,9 @@ class CamelRouteParseCatalogTest {
                 "bridgeErrorHandler", new BooleanParameter("bridgeErrorHandler", "Bridge Error Handler", "d2", false),
                 "exceptionHandler", new ObjectParameter("exceptionHandler", "Exception Handler", "d3", null),
                 "exchangePattern", new ObjectParameter("exchangePattern", "Exchange Pattern", "d4", null),
-                "lazyStartProducer", new BooleanParameter("lazyStartProducer", "Lazy Start Producer", "d5", false)
+                "lazyStartProducer", new BooleanParameter("lazyStartProducer", "Lazy Start Producer", "d5", false),
+                "step-id-kaoto", new StringParameter("step-id-kaoto", "Step ID", "Identifier of this step inside the " +
+                        "route.", null, null)
         );
 
         expectedParameterValues.get("name").setPath(true);

--- a/kamelet-support/src/test/java/io/kaoto/backend/model/deployment/kamelet/step/marshal/SerializationTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/model/deployment/kamelet/step/marshal/SerializationTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresenter;
-import io.kaoto.backend.model.deployment.kamelet.Kamelet;
 import io.kaoto.backend.model.deployment.kamelet.step.MarshalFlowStep;
 import io.kaoto.backend.model.deployment.kamelet.step.dataformat.DataFormat;
 import io.quarkus.test.junit.QuarkusTest;

--- a/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/eip.kamelet.yaml
+++ b/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/eip.kamelet.yaml
@@ -29,40 +29,38 @@ spec:
           copy: true
           steps:
           - saga:
-              completion:
-                uri: direct:completion
               propagation: MANDATORY
-              description:
-                text: SAGA powered step
-                lang: eng
+              completion-mode: MANUAL
+              timeout: '500'
               compensation:
                 uri: direct:compensation
-              completion-mode: MANUAL
-              steps:
-              - to:
-                  uri: direct:something
-              - sample:
-                  description:
-                    text: Message Sampler
-                    lang: eng
-                  sample-period: '1500'
-                  message-frequency: 5
-              - script:
-                  groovy: some groovy script
-              timeout: '500'
               option:
               - key: o1
                 simple: ${body}
               - key: o2
                 expression:
                   simple: ${body}
+              description:
+                text: SAGA powered step
+                lang: eng
+              steps:
+              - to:
+                  uri: direct:something
+              - sample:
+                  sample-period: '1500'
+                  message-frequency: 5
+                  description:
+                    text: Message Sampler
+                    lang: eng
+          - script:
+              groovy: some groovy script
           - delay:
               expression:
                 simple: ${body}
               async-delayed: true
           - throw-exception:
-              exception-type: java.lang.IllegalArgumentException
               message: test
+              exception-type: java.lang.IllegalArgumentException
           - routing-slip:
               simple: ${body}
               uri-delimiter: '|'
@@ -82,14 +80,14 @@ spec:
                 json:
                   library: Gson
             - threads:
-                pool-size: 5
-                max-pool-size: 10
                 description:
                   text: Hilos
                   lang: spa
-                thread-name: threads
-                max-queue-size: 12
+                pool-size: 5
+                max-pool-size: 10
                 keep-alive-time: 5
+                max-queue-size: 12
+                thread-name: threads
             - circuit-breaker:
                 configuration: config
                 description:
@@ -140,8 +138,8 @@ spec:
                 - remove-property:
                     name: property
             - multicast:
-                stop-on-exception: true
                 parallel-processing: true
+                stop-on-exception: true
                 steps:
                 - pipeline:
                     steps:
@@ -169,8 +167,8 @@ spec:
                 parallel-processing: true
                 stop-on-exception: true
             - remove-headers:
-                exclude-pattern: toExclude
                 pattern: toRemove
+                exclude-pattern: toExclude
             - validate:
                 simple: ${body} == 100
             - resequence:
@@ -182,8 +180,8 @@ spec:
                 - transform:
                     simple: baz
                 - remove-properties:
-                    exclude-pattern: toExclude
                     pattern: toRemove
+                    exclude-pattern: toExclude
             - load-balance:
                 weighted:
                   distribution-ratio: 2,1

--- a/model/src/main/java/io/kaoto/backend/model/step/Step.java
+++ b/model/src/main/java/io/kaoto/backend/model/step/Step.java
@@ -46,6 +46,8 @@ public class Step extends Metadata {
     @JsonView(Views.Summary.class)
     @JsonProperty("UUID")
     private String uuid;
+    @JsonView(Views.Complete.class)
+    private String stepId;
 
     public Step() {
         setType(MIDDLE);
@@ -219,6 +221,21 @@ public class Step extends Metadata {
 
     public void setMaxBranches(final Integer maxBranches) {
         this.maxBranches = maxBranches;
+    }
+
+
+    /*
+     * 🐱property id: String
+     *
+     * User defined id for this step.
+     *
+     */
+    public String getStepId() {
+        return stepId;
+    }
+
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/model/src/main/java/io/kaoto/backend/model/step/Step.java
+++ b/model/src/main/java/io/kaoto/backend/model/step/Step.java
@@ -240,9 +240,11 @@ public class Step extends Metadata {
     }
 
     public void setStepId(final String stepId) {
-        this.getParameters().stream()
-                .filter(parameter -> parameter.getId().equalsIgnoreCase("step-id-kaoto"))
-                .findAny().ifPresent(parameter -> parameter.setValue(stepId));
+        if (this.getParameters() != null) {
+            this.getParameters().stream()
+                    .filter(parameter -> parameter.getId().equalsIgnoreCase("step-id-kaoto"))
+                    .findAny().ifPresent(parameter -> parameter.setValue(stepId));
+        }
     }
 
     @Override

--- a/model/src/main/java/io/kaoto/backend/model/step/Step.java
+++ b/model/src/main/java/io/kaoto/backend/model/step/Step.java
@@ -46,8 +46,6 @@ public class Step extends Metadata {
     @JsonView(Views.Summary.class)
     @JsonProperty("UUID")
     private String uuid;
-    @JsonView(Views.Complete.class)
-    private String stepId;
 
     public Step() {
         setType(MIDDLE);
@@ -231,11 +229,20 @@ public class Step extends Metadata {
      *
      */
     public String getStepId() {
-        return stepId;
+        var p = this.getParameters().stream()
+                .filter(parameter -> parameter.getId().equalsIgnoreCase("step-id-kaoto"))
+                .findAny();
+        if (p.isPresent() && p.get().getValue() != null) {
+            return String.valueOf(p.get().getValue());
+        } else {
+            return null;
+        }
     }
 
-    public void setStepId(String stepId) {
-        this.stepId = stepId;
+    public void setStepId(final String stepId) {
+        this.getParameters().stream()
+                .filter(parameter -> parameter.getId().equalsIgnoreCase("step-id-kaoto"))
+                .findAny().ifPresent(parameter -> parameter.setValue(stepId));
     }
 
     @Override


### PR DESCRIPTION
This is the backend side of https://github.com/KaotoIO/kaoto-backend/issues/526

Now the JSON steps may contain a new attribute called `stepId` that contains the id of the step.

For example, a call to `/v1/integrations` may answer something like...

```
{
  "steps": [
    {
      "name": "as2",
      "type": "START",
      "id": "as2-consumer",
      "kind": "Camel-Connector",
      "title": "AS2",
      "description": "Transfer data securely and reliably using the AS2 protocol (RFC4130).",
      "group": "Camel-Component",
      "parameters": [...],
      "required": [
        "apiName",
        "methodName"
      ],
      "branches": null,
      "minBranches": 0,
      "maxBranches": 0,
      "stepId": "patatas",
      "UUID": null
    }
  ],
  "metadata": null,
  "parameters": null,
  "dsl": "Camel Route"
}
```