### PR TITLE
fix: Sending an END step when it should be middle

### DIFF
--- a/api/src/test/resources/io/kaoto/backend/api/resource/uri-log-stop.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/uri-log-stop.yaml
@@ -1,0 +1,16 @@
+- from:
+    uri: "direct:start"
+    steps:
+      - filter:
+          expression:
+            simple: "${in.header.continue} == true"
+          steps:
+            - to:
+                uri: "log:filtered"
+      - filter:
+          expression:
+            simple: "${in.header.stop} == true"
+          steps:
+            - stop:
+      - to:
+          uri: "log:original"

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/StopFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/StopFlowStep.java
@@ -33,9 +33,15 @@ public class StopFlowStep implements FlowStep {
     @Override
     public Step getStep(final StepCatalog catalog, final KameletStepParserService kameletStepParserService,
                         final Boolean start, final Boolean end) {
-        return catalog.getReadOnlyCatalog()
+        var stopEip= catalog.getReadOnlyCatalog()
                 .searchByName("stop").stream()
                 .filter(step -> step.getKind().equalsIgnoreCase("EIP"))
                 .findAny().orElse(null);
+        if (stopEip != null) {
+            // @FIXME this is a workaround for https://github.com/KaotoIO/kaoto-ui/issues/1587
+            // Once UI implements the END step handling, STOP EIP has to get back to be an END step
+            stopEip.setType("MIDDLE");
+        }
+        return stopEip;
     }
 }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/UriFlowStep.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/UriFlowStep.java
@@ -115,15 +115,18 @@ public class UriFlowStep implements FlowStep {
             });
         } else {
             candidates = candidates.sorted((step, step2) -> {
+                //EIPs shouldn't go through this function
+                if (step.getKind().startsWith("EIP")) {
+                    return 1;
+                }
+                if (step2.getKind().startsWith("EIP")) {
+                    return -1;
+                }
+
                 var type = Step.Type.valueOf(step.getType());
                 var type2 = Step.Type.valueOf(step2.getType());
                 if (type.equals(type2)) {
                     return 0;
-                }
-
-                //EIPs shouldn't go through this function
-                if (step.getKind().startsWith("EIP")) {
-                    return 10000;
                 }
 
                 if (type == Step.Type.MIDDLE) {

--- a/model/src/main/java/io/kaoto/backend/model/step/Step.java
+++ b/model/src/main/java/io/kaoto/backend/model/step/Step.java
@@ -255,6 +255,8 @@ public class Step extends Metadata {
                 + ", uuid=" + getUUID() + '\n'
                 + ", title=" + getTitle() + '\n'
                 + ", type=" + getType() + '\n'
+                + ", kind='" + getKind() + '\'' + '\n'
+                + ", group='" + getGroup() + '\'' + '\n'
                 + '}';
     }
 


### PR DESCRIPTION
Fixes: #586

This also applies a workaround for KaotoIO/kaoto-ui#1587, change the `stop` EIP to be `MIDDLE` type while it's actually an `END`. We need to get this back to be `END` once KaotoIO/kaoto-ui#1587 is implemented