### PR TITLE
fix: Proper path parsing. 

### DIFF
--- a/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
+++ b/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
@@ -68,7 +68,7 @@ class CamelRouteStepParserServiceTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"route.yaml", "route2-complex-expressions.yaml",
-            "route3-complex-expressions.yaml", "route-ids.yaml", "route4-pathparams.yaml"})
+            "route3-complex-expressions.yaml", "route-ids.yaml", "route4-pathparams.yaml", "route5-placeholders.yaml"})
     void deepParseParametrized(String file) throws IOException {
         var route = new String(this.getClass().getResourceAsStream(file).readAllBytes(),
                 StandardCharsets.UTF_8);

--- a/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route5-placeholders.yaml
+++ b/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route5-placeholders.yaml
@@ -1,0 +1,5 @@
+- from:
+    uri: file:{{customer.file.directory}}
+    steps:
+    - to:
+        uri: sftp://{{sftphost}}:22/files/process

--- a/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
@@ -297,6 +297,9 @@ public class KamelPopulator {
                 for (Parameter p : step.getParameters()) {
                     var value = values.get(p.getId());
                     if (p.isPath()) {
+                        if (p.getPathOrder() == 0) {
+                            uri.append(":");
+                        }
                         uri.append(p.getPathSeparator());
                         //Look for the right value
                         value = value != null ? value : p.getDefaultValue();

--- a/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
+++ b/kamelet-support/src/test/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserServiceTest.java
@@ -184,9 +184,7 @@ class KameletStepParserServiceTest {
         assertEquals(parsed.getSteps(), parsed2.getSteps());
         assertEquals(parsed.getMetadata().keySet(),
                 parsed2.getMetadata().keySet());
-        for (String key : new String[]{"labels", "annotations",
-                "additionalProperties",
-                "name"}) {
+        for (String key : new String[]{"labels", "annotations", "additionalProperties", "name"}) {
             assertEquals(parsed.getMetadata().get(key),
                     parsed2.getMetadata().get(key));
         }

--- a/model/src/main/java/io/kaoto/backend/model/parameter/Parameter.java
+++ b/model/src/main/java/io/kaoto/backend/model/parameter/Parameter.java
@@ -233,7 +233,7 @@ public abstract class Parameter<T> implements Cloneable, Comparable<Parameter<T>
 
     @Override
     public int compareTo(Parameter other) {
-        return Integer.compare(other.getPathOrder(), this.getPathOrder());
+        return Integer.compare(this.getPathOrder(), other.getPathOrder());
     }
 
     @Override


### PR DESCRIPTION
When generating camel connectors for the catalog, the order was wrong. Plus, using the split characters as part of the field.

Fixes #577