### PR TITLE
fix: unable to start container process on OpenShift

### DIFF
--- a/api/src/main/docker/Dockerfile.jvm
+++ b/api/src/main/docker/Dockerfile.jvm
@@ -37,7 +37,7 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
     && chown 1001:root /deployments \
     && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
     && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
+    && chmod 755 /deployments/run-java.sh \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/conf/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.

--- a/api/src/main/docker/Dockerfile.legacy-jar
+++ b/api/src/main/docker/Dockerfile.legacy-jar
@@ -37,7 +37,7 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
     && chown 1001:root /deployments \
     && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
     && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
+    && chmod 755 /deployments/run-java.sh \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/conf/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.


### PR DESCRIPTION
Running the container image on OpenShift fails with:

```
unable to start container process: exec /deployments/run-java.sh: permission denied
```

Fixes #609.