### PR TITLE
617 Fix expression support with native build

### DIFF
--- a/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceIT.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceIT.java
@@ -1,0 +1,8 @@
+package io.kaoto.backend.api.resource.v1;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class IntegrationsResourceIT extends IntegrationsResourceTest {
+
+}

--- a/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceTest.java
@@ -6,139 +6,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import io.kaoto.backend.model.deployment.kamelet.expression.Expression;
-import io.kaoto.backend.model.step.Step;
-import org.junit.jupiter.api.BeforeEach;
+import javax.ws.rs.core.Response;
+
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.kaoto.backend.api.metadata.catalog.StepCatalog;
 import io.kaoto.backend.api.resource.v1.model.Integration;
 import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresenter;
-import io.kaoto.backend.api.service.language.LanguageService;
 import io.kaoto.backend.model.deployment.kamelet.KameletBinding;
+import io.kaoto.backend.model.step.Step;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @TestHTTPEndpoint(IntegrationsResource.class)
 class IntegrationsResourceTest {
-
-    private StepCatalog catalog;
-    private LanguageService languageService;
-    @Inject
-    public void setStepCatalog(final StepCatalog catalog) {
-        this.catalog = catalog;
-    }
-
-    @Inject
-    public void setLanguageService(final LanguageService languageService) {
-        this.languageService = languageService;
-    }
-
-    @BeforeEach
-    void ensureCatalog() {
-        catalog.waitForWarmUp().join();
-    }
-
-    @Test
-    void thereAndBackAgain() throws URISyntaxException, IOException {
-
-        final var alldsl = languageService.getAll();
-        ObjectMapper mapper = new ObjectMapper();
-
-        String yaml1 = Files.readString(Path.of(
-                DeploymentsResourceTest.class.getResource(
-                                "../twitter-search-source-binding.yaml")
-                        .toURI()));
-
-        var res = given()
-                .when()
-                .contentType("application/json")
-                .body(Collections.emptyList())
-                .post("/dsls")
-                .then()
-                .statusCode(Response.Status.OK.getStatusCode());
-        final var dsllist = mapper.readValue(res.extract().body().asString(), List.class);
-        assertEquals(alldsl.size(), dsllist.size());
-        assertTrue(alldsl.stream().allMatch(l -> dsllist.contains(l.get("name"))));
-
-        //It will return a valid value even if we are useless users with the DSL
-        given()
-                .when()
-                .contentType("text/yaml")
-                .body(yaml1)
-                .post("?dsl=SomethingWrong")
-                .then()
-                .statusCode(Response.Status.OK.getStatusCode());
-
-        res = given()
-                .when()
-                .contentType("text/yaml")
-                .body(yaml1)
-                .post("?dsl=KameletBinding")
-                .then()
-                .statusCode(Response.Status.OK.getStatusCode());
-
-        String json = res.extract().body().asString();
-        Integration integration = mapper.readValue(json, Integration.class);
-
-        res = given()
-                .when()
-                .contentType("application/json")
-                .body(Collections.emptyList())
-                .post("/dsls")
-                .then()
-                .statusCode(Response.Status.OK.getStatusCode());
-        final var dsllist2 = mapper.readValue(res.extract().body().asString(), List.class);
-        assertEquals(alldsl.size(), dsllist2.size());
-        assertTrue(alldsl.stream().allMatch(l -> dsllist2.contains(l.get("name"))));
-
-        res = given()
-                .when()
-                .contentType("application/json")
-                .body(integration.getSteps())
-                .post("/dsls")
-                .then()
-                .statusCode(Response.Status.OK.getStatusCode());
-        var dsls = mapper.readValue(res.extract().body().asString(), List.class);
-        assertEquals(1, dsls.size());
-        assertTrue(dsls.contains("KameletBinding"));
-
-        res = given()
-                .when()
-                .contentType("application/json")
-                .body(json)
-                .post("?dsl=KameletBinding")
-                .then()
-                .statusCode(Response.Status.OK.getStatusCode());
-
-        String yaml2 = res.extract().body().asString();
-
-        Yaml yaml = new Yaml(
-                new Constructor(KameletBinding.class),
-                new KameletRepresenter());
-        KameletBinding res1 = yaml.load(yaml1);
-        KameletBinding res2 = yaml.load(yaml2);
-
-        assertEquals(res1, res2);
-
-    }
-
 
     @Test
     void complexEIP() throws URISyntaxException, IOException {

--- a/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceWithServiceAccessTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v1/IntegrationsResourceWithServiceAccessTest.java
@@ -1,0 +1,137 @@
+package io.kaoto.backend.api.resource.v1;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kaoto.backend.api.metadata.catalog.StepCatalog;
+import io.kaoto.backend.api.resource.v1.model.Integration;
+import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresenter;
+import io.kaoto.backend.api.service.language.LanguageService;
+import io.kaoto.backend.model.deployment.kamelet.KameletBinding;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@TestHTTPEndpoint(IntegrationsResource.class)
+class IntegrationsResourceWithServiceAccessTest {
+
+	private StepCatalog catalog;
+    private LanguageService languageService;
+    @Inject
+    public void setStepCatalog(final StepCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @Inject
+    public void setLanguageService(final LanguageService languageService) {
+        this.languageService = languageService;
+    }
+
+    @BeforeEach
+    void ensureCatalog() {
+        catalog.waitForWarmUp().join();
+    }
+
+    @Test
+    void thereAndBackAgain() throws URISyntaxException, IOException {
+
+        final var alldsl = languageService.getAll();
+        ObjectMapper mapper = new ObjectMapper();
+
+        String yaml1 = Files.readString(Path.of(
+                DeploymentsResourceTest.class.getResource(
+                                "../twitter-search-source-binding.yaml")
+                        .toURI()));
+
+        var res = given()
+                .when()
+                .contentType("application/json")
+                .body(Collections.emptyList())
+                .post("/dsls")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+        final var dsllist = mapper.readValue(res.extract().body().asString(), List.class);
+        assertEquals(alldsl.size(), dsllist.size());
+        assertTrue(alldsl.stream().allMatch(l -> dsllist.contains(l.get("name"))));
+
+        //It will return a valid value even if we are useless users with the DSL
+        given()
+                .when()
+                .contentType("text/yaml")
+                .body(yaml1)
+                .post("?dsl=SomethingWrong")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+
+        res = given()
+                .when()
+                .contentType("text/yaml")
+                .body(yaml1)
+                .post("?dsl=KameletBinding")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+
+        String json = res.extract().body().asString();
+        Integration integration = mapper.readValue(json, Integration.class);
+
+        res = given()
+                .when()
+                .contentType("application/json")
+                .body(Collections.emptyList())
+                .post("/dsls")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+        final var dsllist2 = mapper.readValue(res.extract().body().asString(), List.class);
+        assertEquals(alldsl.size(), dsllist2.size());
+        assertTrue(alldsl.stream().allMatch(l -> dsllist2.contains(l.get("name"))));
+
+        res = given()
+                .when()
+                .contentType("application/json")
+                .body(integration.getSteps())
+                .post("/dsls")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+        var dsls = mapper.readValue(res.extract().body().asString(), List.class);
+        assertEquals(1, dsls.size());
+        assertTrue(dsls.contains("KameletBinding"));
+
+        res = given()
+                .when()
+                .contentType("application/json")
+                .body(json)
+                .post("?dsl=KameletBinding")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+
+        String yaml2 = res.extract().body().asString();
+
+        Yaml yaml = new Yaml(
+                new Constructor(KameletBinding.class),
+                new KameletRepresenter());
+        KameletBinding res1 = yaml.load(yaml1);
+        KameletBinding res2 = yaml.load(yaml2);
+
+        assertEquals(res1, res2);
+
+    }
+	
+}

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/CSimple.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/CSimple.java
@@ -3,10 +3,13 @@ package io.kaoto.backend.model.deployment.kamelet.expression;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonPropertyOrder({CSimple.EXPRESSION_LABEL, CSimple.ID_LABEL, CSimple.RESULT_TYPE_LABEL, CSimple.TRIM_LABEL})
+@RegisterForReflection
 public class CSimple {
     public static final String EXPRESSION_LABEL = "expression";
     public static final String ID_LABEL = "id";

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Expression.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Expression.java
@@ -7,10 +7,12 @@ import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresen
 import io.kaoto.backend.model.deployment.kamelet.step.EIPStep;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.Map;
 
 @JsonPropertyOrder({"name", "constant", "simple", "jq", "jsonpath", "expression"})
+@RegisterForReflection
 public class Expression extends EIPStep {
     public static final String CONSTANT_LABEL = KameletRepresenter.CONSTANT;
     public static final String SIMPLE_LABEL = KameletRepresenter.SIMPLE;

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Groovy.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Groovy.java
@@ -3,10 +3,13 @@ package io.kaoto.backend.model.deployment.kamelet.expression;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonPropertyOrder({Groovy.EXPRESSION_LABEL, Groovy.ID_LABEL, Groovy.RESULT_TYPE_LABEL, Groovy.TRIM_LABEL})
+@RegisterForReflection
 public class Groovy {
     public static final String EXPRESSION_LABEL = "expression";
     public static final String ID_LABEL = "id";

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Javascript.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Javascript.java
@@ -3,6 +3,8 @@ package io.kaoto.backend.model.deployment.kamelet.expression;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,6 +13,7 @@ import java.util.Map;
         Javascript.ID_LABEL,
         Javascript.RESULT_TYPE_LABEL,
         Javascript.TRIM_LABEL})
+@RegisterForReflection
 public class Javascript {
     public static final String EXPRESSION_LABEL = "expression";
     public static final String ID_LABEL = "id";

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Jq.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Jq.java
@@ -3,10 +3,13 @@ package io.kaoto.backend.model.deployment.kamelet.expression;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonPropertyOrder({Jq.EXPRESSION_LABEL, Jq.ID_LABEL, Jq.RESULT_TYPE_LABEL, Jq.TRIM_LABEL})
+@RegisterForReflection
 public class Jq {
     public static final String EXPRESSION_LABEL = "expression";
     public static final String ID_LABEL = "id";

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/JsonPath.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/JsonPath.java
@@ -3,10 +3,13 @@ package io.kaoto.backend.model.deployment.kamelet.expression;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 @JsonPropertyOrder({JsonPath.EXPRESSION_LABEL, JsonPath.ID_LABEL, JsonPath.RESULT_TYPE_LABEL, JsonPath.TRIM_LABEL})
+@RegisterForReflection
 public class JsonPath {
     public static final String EXPRESSION_LABEL = "expression";
     public static final String ALLOW_EASY_PREDICATE_LABEL = "allow-easy-predicate";

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Script.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Script.java
@@ -6,11 +6,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresenter;
 import io.kaoto.backend.model.deployment.kamelet.step.EIPStep;
 import io.kaoto.backend.model.parameter.Parameter;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 @JsonPropertyOrder({"name", "groovy", "javascript", "expression"})
+@RegisterForReflection
 public class Script extends EIPStep {
     public static final String GROOVY_LABEL = KameletRepresenter.GROOVY;
     public static final String JAVASCRIPT_LABEL = KameletRepresenter.JAVASCRIPT;

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/ScriptExpression.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/ScriptExpression.java
@@ -7,10 +7,12 @@ import io.kaoto.backend.api.service.deployment.generator.kamelet.KameletRepresen
 import io.kaoto.backend.model.deployment.kamelet.step.EIPStep;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.Map;
 
 @JsonPropertyOrder({"name", "groovy", "javascript", "expression"})
+@RegisterForReflection
 public class ScriptExpression extends EIPStep {
     public static final String GROOVY_LABEL = KameletRepresenter.GROOVY;
     public static final String JAVASCRIPT_LABEL = KameletRepresenter.JAVASCRIPT;

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Tokenizer.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/expression/Tokenizer.java
@@ -3,10 +3,12 @@ package io.kaoto.backend.model.deployment.kamelet.expression;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kaoto.backend.model.parameter.Parameter;
 import io.kaoto.backend.model.step.Step;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@RegisterForReflection
 public class Tokenizer extends Expression {
     public static final String TOKEN_LABEL = "token";
     public static final String END_TOKEN_LABEL = "end-token-label";


### PR DESCRIPTION
* Fix expression support in native mode: the Expression related classes were missing from native build. Registered all of them for reflection. It might be possible to be more specific and register a single one. To be investigated and potentially improved in another iteration
* Provide native tests for Integrations resource:
  * it allows to have a non-regression test for #617 issue with expressions
  * extracted a single test from IntegrationsResourceTest which cannot be launch in Native mode because it is using @Inject to access internal services directly. it allows to inherit the native test class from IntegrationsResourceTest and play all of the existing tests in native
 
fixes #617
part of #437