### PR TITLE
fix: http and https behave slightly different when building the uri

### DIFF
--- a/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
+++ b/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
@@ -59,6 +59,11 @@ class CamelRouteStepParserServiceTest {
         assertTrue(steps.getMetadata() == null || steps.getMetadata().isEmpty());
         assertFalse(steps.getSteps().isEmpty());
 
+        var https = steps.getSteps().get(3);
+        assertTrue(https.getParameters().stream().anyMatch(
+                p -> "httpUri".equalsIgnoreCase(p.getId())
+                        && "https://mycustom.url:42/with/things".equals(p.getValue())));
+
         var yaml = camelRouteDeploymentGeneratorService.parse(steps.getSteps(), steps.getMetadata(),
                 steps.getParameters());
         assertThat(yaml).isEqualToNormalizingNewlines(route);

--- a/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route.yaml
+++ b/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route.yaml
@@ -7,3 +7,5 @@
         constant: Hello Camel K from yaml
     - to:
         uri: log:info
+    - to:
+        uri: https://mycustom.url:42/with/things

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
@@ -197,8 +197,7 @@ public class KameletStepParserService
         if (step.getName().equalsIgnoreCase("http")
                 || step.getName().equalsIgnoreCase("https")) {
             path = step.getName() + ":" + path;
-        }
-        if (path.contains("?")) {
+        } else if (path.contains("?")) {
             path = path.substring(0, path.indexOf('?'));
         }
         var pathParameters = new LinkedList<Parameter>();

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
@@ -194,6 +194,10 @@ public class KameletStepParserService
     public void setValuesOnParameters(final Step step, final String uri) {
 
         String path = uri.substring(uri.indexOf(':') + 1);
+        if (step.getName().equalsIgnoreCase("http")
+                || step.getName().equalsIgnoreCase("https")) {
+            path = step.getName() + ":" + path;
+        }
         if (path.contains("?")) {
             path = path.substring(0, path.indexOf('?'));
         }


### PR DESCRIPTION
We want to prevent a duplicated http/https if httpUri is defined in the frontend with the http/https already included.

![image](https://user-images.githubusercontent.com/726590/231111037-b55acc65-a1ff-410f-b1b8-4c1f0619ad46.png)
