### PR TITLE
feature: Add beans support for Camel Route (KaotoIO/kaoto-ui#1721)

### DIFF
--- a/api/src/main/java/io/kaoto/backend/api/resource/model/FlowsWrapper.java
+++ b/api/src/main/java/io/kaoto/backend/api/resource/model/FlowsWrapper.java
@@ -10,14 +10,15 @@ import java.util.Map;
  * Used by the API to pass flows back and forth.
  *
  */
-public record FlowsWrapper(List<Integration> flows, Map<String, Object> properties) {
+public record FlowsWrapper(List<Integration> flows, Map<String, Object> metadata, Map<String, Object> properties) {
 
     public FlowsWrapper(List<Integration> flows) {
-        this(flows, null);
+        this(flows, null, null);
     }
 
-    public FlowsWrapper(List<Integration> flows, Map<String, Object> properties) {
+    public FlowsWrapper(List<Integration> flows, Map<String, Object> metadata, Map<String, Object> properties) {
         this.flows = flows;
+        this.metadata = metadata;
         this.properties = properties;
     }
 }

--- a/api/src/main/java/io/kaoto/backend/api/service/deployment/DeploymentService.java
+++ b/api/src/main/java/io/kaoto/backend/api/service/deployment/DeploymentService.java
@@ -117,7 +117,7 @@ public class DeploymentService {
      * Based on the provided steps, return a valid yaml string to deploy
      */
     @WithSpan
-    public String crds(final List<Integration> i, final String dsl) {
+    public String crds(final List<Integration> i, final Map<String, Object> metadata, final String dsl) {
         List<StepParserService.ParseResult<Step>> integrations = new LinkedList<>();
 
         for (Integration integration : i) {
@@ -125,6 +125,12 @@ public class DeploymentService {
             parseResult.setMetadata(integration.getMetadata());
             parseResult.setSteps(integration.getSteps());
             parseResult.setParameters(integration.getParameters());
+            integrations.add(parseResult);
+        }
+
+        if (metadata != null && !metadata.isEmpty()) {
+            var parseResult = new StepParserService.ParseResult<Step>();
+            parseResult.setMetadata(metadata);
             integrations.add(parseResult);
         }
 

--- a/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
@@ -336,7 +336,8 @@ class IntegrationsResourceTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"Camel Route#route-multi.yaml", "KameletBinding#kamelet-binding-multi.yaml",
-            "Kamelet#eip.kamelet.yaml", "Kamelet#kamelet-multi.yaml", "Camel Route#rest-dsl-multi.yaml"})
+            "Kamelet#eip.kamelet.yaml", "Kamelet#kamelet-multi.yaml", "Camel Route#rest-dsl-multi.yaml",
+            "Camel Route#route-with-beans.yaml"})
     void roundTrip(String file) throws IOException {
 
         String[] parameters = file.split("#");

--- a/api/src/test/resources/io/kaoto/backend/api/resource/route-with-beans.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/route-with-beans.yaml
@@ -1,0 +1,26 @@
+- from:
+    uri: 'netty-http:http://0.0.0.0:8080:'
+    steps:
+    - to:
+        uri: sql:select * from actor
+        parameters:
+          dataSource:
+            ref: dataSource
+    - marshal:
+        json:
+          library: Jackson
+- beans:
+  - name: dataSource
+    type: org.postgresql.ds.PGSimpleDataSource
+    properties:
+      serverName: 127.0.0.1
+      portNumber: '5432'
+      databaseName: dvdrental
+      user: user
+      password: password
+  - name: someBean
+    type: io.kaoto.test.backend.api.service.step.parser.camelroute.SomeBean
+    properties:
+      someProperty: someValue
+      someObjectProperty:
+        someObjectPropertyProperty: someObjectPropertyValue

--- a/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/CamelRouteDeploymentGeneratorService.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/CamelRouteDeploymentGeneratorService.java
@@ -82,7 +82,7 @@ public class CamelRouteDeploymentGeneratorService implements DeploymentGenerator
                         final Map<String, Object> metadata,
                         final List<Parameter> parameters) {
         Yaml yaml = new Yaml(new Constructor(CamelRoute.class), new CamelRouteRepresenter());
-        return yaml.dumpAs(new CamelRoute(steps, catalog), Tag.SEQ, DumperOptions.FlowStyle.BLOCK);
+        return yaml.dumpAs(new CamelRoute(steps, metadata, catalog), Tag.SEQ, DumperOptions.FlowStyle.BLOCK);
     }
 
     @Override

--- a/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/CamelRouteRepresenter.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/api/service/deployment/generator/camelroute/CamelRouteRepresenter.java
@@ -1,10 +1,17 @@
 package io.kaoto.backend.api.service.deployment.generator.camelroute;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.kaoto.backend.model.deployment.camelroute.Bean;
 import io.kaoto.backend.model.deployment.camelroute.CamelRoute;
 import io.kaoto.backend.model.deployment.rest.HttpVerb;
 import io.kaoto.backend.model.deployment.rest.Rest;
 import io.kaoto.backend.model.deployment.rest.RestParameter;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.introspector.BeanAccess;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
@@ -13,13 +20,34 @@ public class CamelRouteRepresenter extends IntegrationRepresenter {
 
     public CamelRouteRepresenter() {
         super();
+        this.getPropertyUtils().setBeanAccess(BeanAccess.FIELD);
+
         this.multiRepresenters.put(CamelRoute.class,
                 new RepresentMap() {
                     @Override
                     public Node representData(final Object data) {
-                        return representSequence(getTag(data.getClass(), Tag.SEQ),
-                                ((CamelRoute) data).getFlows(),
+                        CamelRoute route = (CamelRoute) data;
+                        List<Object> properties = new ArrayList<>();
+                        if (route.getFlows() != null) {
+                            properties.addAll(route.getFlows());
+                        }
+                        if (route.getBeans() != null) {
+                            Map<String, Object> beans = new LinkedHashMap<>();
+                            beans.put("beans", route.getBeans());
+                            properties.add(beans);
+                        }
+                        return representSequence(getTag(Object.class, Tag.SEQ),
+                                properties,
                                 DumperOptions.FlowStyle.BLOCK);
+                    }
+                });
+        this.multiRepresenters.put(Bean.class,
+                new RepresentMap() {
+                    @Override
+                    public Node representData(final Object data) {
+                        return representMapping(getTag(data.getClass(), Tag.MAP),
+                                ((Bean) data).getRepresenterProperties(),
+                                DumperOptions.FlowStyle.AUTO);
                     }
                 });
         this.multiRepresenters.put(Rest.class,

--- a/camel-route-support/src/main/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteDeserializer.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteDeserializer.java
@@ -1,0 +1,56 @@
+package io.kaoto.backend.api.service.step.parser.camelroute;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.type.CollectionType;
+
+import io.kaoto.backend.model.deployment.camelroute.Bean;
+import io.kaoto.backend.model.deployment.camelroute.CamelRoute;
+import io.kaoto.backend.model.deployment.kamelet.Flow;
+
+public class CamelRouteDeserializer extends StdDeserializer<CamelRoute> {
+
+    protected CamelRouteDeserializer() {
+        this(null);
+    }
+
+    protected CamelRouteDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public CamelRoute deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        CamelRoute answer = new CamelRoute();
+        ArrayNode root = (ArrayNode) p.getCodec().readTree(p);
+        Iterator<JsonNode> fields = root.elements();
+        while (fields.hasNext()) {
+            var field = fields.next();
+            if (field.has("from") || field.has("rest")) {
+                Flow flow = ctxt.readTreeAsValue(field, Flow.class);
+                if (answer.getFlows() == null) {
+                    answer.setFlows(new LinkedList<>());
+                }
+                answer.getFlows().add(flow);
+            } else if (field.has("beans")) {
+                CollectionType beansType = ctxt.getTypeFactory().constructCollectionType(List.class, Bean.class);
+                List<Bean> beans = ctxt.readTreeAsValue(field.get("beans"), beansType);
+                if (answer.getBeans() == null) {
+                    answer.setBeans(new LinkedList<>());
+                }
+                answer.getBeans().addAll(beans);
+            } else {
+                throw new IOException("'" + field.fields().next().getKey()
+                        + "' is not supported as a root element of Camel Route");
+            }
+        }
+        return answer;
+    }
+}

--- a/camel-route-support/src/main/java/io/kaoto/backend/model/deployment/camelroute/Bean.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/model/deployment/camelroute/Bean.java
@@ -1,0 +1,75 @@
+package io.kaoto.backend.model.deployment.camelroute;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@JsonPropertyOrder({ "name", "type", "properties" })
+@JsonDeserialize(
+        using = JsonDeserializer.None.class
+)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Bean implements Serializable {
+    private static final long serialVersionUID = -4601560033032557024L;
+
+    public static final String NAME_LABEL = "name";
+    public static final String TYPE_LABEL = "type";
+    public static final String PROPERTIES_LABEL = "properties";
+
+    public Bean() {
+        super();
+    }
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("properties")
+    private Map<String, Object> properties;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(final Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+    @JsonIgnore
+    public Map<String, Object> getRepresenterProperties() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        if (this.getName() != null) {
+            props.put(NAME_LABEL, this.getName());
+        }
+        if (this.getType() != null) {
+            props.put(TYPE_LABEL, this.getType());
+        }
+        if (this.getProperties() != null) {
+            props.put(PROPERTIES_LABEL, this.getProperties());
+        }
+        return props;
+    }
+}

--- a/camel-route-support/src/main/java/io/kaoto/backend/model/deployment/camelroute/CamelRoute.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/model/deployment/camelroute/CamelRoute.java
@@ -1,8 +1,12 @@
 package io.kaoto.backend.model.deployment.camelroute;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import io.kaoto.backend.KamelPopulator;
 import io.kaoto.backend.api.metadata.catalog.StepCatalog;
+import io.kaoto.backend.api.service.step.parser.camelroute.CamelRouteDeserializer;
 import io.kaoto.backend.model.deployment.kamelet.Flow;
 import io.kaoto.backend.model.deployment.rest.HttpVerb;
 import io.kaoto.backend.model.deployment.rest.Rest;
@@ -11,22 +15,35 @@ import org.jboss.logging.Logger;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 🐱class CamelRoute
  */
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = CamelRouteDeserializer.class)
 public class CamelRoute {
 
     protected static final Logger log = Logger.getLogger(CamelRoute.class);
     private List<Flow> flows;
 
+    @JsonProperty("beans")
+    private List<Bean> beans;
+
     public CamelRoute() {
         super();
     }
 
-    public CamelRoute(final List<Step> steps, final StepCatalog catalog) {
+    public CamelRoute(final List<Step> steps, final Map<String, Object> metadata, final StepCatalog catalog) {
+        processFlows(steps, catalog);
+        processBeans(metadata);
+    }
+
+    private void processFlows(final List<Step> steps, final StepCatalog catalog) {
+        if (steps == null) {
+            return;
+        }
         final var flow = new KamelPopulator(catalog).getFlow(steps);
         setFlows(new LinkedList<>());
         if (flow instanceof Rest) {
@@ -63,6 +80,12 @@ public class CamelRoute {
         }
     }
 
+    private void processBeans(final Map<String, Object> metadata) {
+        if (metadata != null && metadata.containsKey("beans") && metadata.get("beans") instanceof List) {
+            setBeans((List<Bean>) metadata.get("beans"));
+        }
+    }
+
     public List<Flow> getFlows() {
         return flows;
     }
@@ -71,5 +94,8 @@ public class CamelRoute {
         this.flows = flows;
     }
 
+    public List<Bean> getBeans() { return beans; }
+
+    public void setBeans(List<Bean> beans) { this.beans = beans; }
 
 }

--- a/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
+++ b/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/CamelRouteStepParserServiceTest.java
@@ -142,4 +142,13 @@ class CamelRouteStepParserServiceTest {
                 steps.getParameters());
         assertThat(yaml).isEqualToNormalizingNewlines(routec);
     }
+
+    @Test
+    void beans() throws Exception {
+        var route = new String(this.getClass().getResourceAsStream("route-with-beans.yaml").readAllBytes(),
+                StandardCharsets.UTF_8);
+        var steps = camelRouteStepParserService.getParsedFlows(route);
+        var yaml = camelRouteDeploymentGeneratorService.parse(steps);
+        assertThat(yaml).isEqualToNormalizingNewlines(route);
+    }
 }

--- a/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route-with-beans.yaml
+++ b/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/route-with-beans.yaml
@@ -1,0 +1,26 @@
+- from:
+    uri: 'netty-http:http://0.0.0.0:8080:'
+    steps:
+    - to:
+        uri: sql:select * from actor
+        parameters:
+          dataSource:
+            ref: dataSource
+    - marshal:
+        json:
+          library: Jackson
+- beans:
+  - name: dataSource
+    type: org.postgresql.ds.PGSimpleDataSource
+    properties:
+      serverName: 127.0.0.1
+      portNumber: '5432'
+      databaseName: dvdrental
+      user: user
+      password: password
+  - name: someBean
+    type: io.kaoto.test.backend.api.service.step.parser.camelroute.SomeBean
+    properties:
+      someProperty: someValue
+      someObjectProperty:
+        someObjectPropertyProperty: someObjectPropertyValue


### PR DESCRIPTION
The backend side of source code level beans support for Camel Route. Verify frontend side once /v2/integrations is wired for source code sync.