### PR TITLE
fix: exclude FlowStepDeserializer exceptions from workflow logs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -74,7 +74,7 @@ jobs:
           disk-root: "C:"
         if: ${{ matrix.os == 'windows-latest' }}
       - name: 🤳 Run native tests
-        run: mvn install -Pnative
+        run: mvn ${{ matrix.os == 'windows-latest' && '--%' || '' }} install -Pnative -Dquarkus.log.category.\"io.kaoto.backend.model.deployment.kamelet.step.FlowStepDeserializer\".level=OFF
       - name: Archive Quarkus log for native tests
         uses: actions/upload-artifact@v3
         if: failure()
@@ -114,5 +114,6 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: 🤳 Run tests
-        run: mvn install
+        run: mvn ${{ matrix.os == 'windows-latest' && '--%' || '' }} install -Dquarkus.log.category.\"io.kaoto.backend.model.deployment.kamelet.step.FlowStepDeserializer\".level=OFF


### PR DESCRIPTION
The test logs in workflows usually have ~32000 lines with a bunch of FlowStepDeserializer errors which slows down the search for a real problem of failure and it is almost impossible to scroll down to the end of the log in a browser.
After this change, the log contains only ~3500 lines