### PR TITLE
chore: fix documentation generation for DSLSpecification

### DIFF
--- a/services-interfaces/src/main/java/io/kaoto/backend/api/service/dsl/DSLSpecification.java
+++ b/services-interfaces/src/main/java/io/kaoto/backend/api/service/dsl/DSLSpecification.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
- * 🐱miniclass DSLSpecification
+ * 🐱class DSLSpecification
  * <p>
  * <p>
  * 🐱section


### PR DESCRIPTION
miniclass of leafdoc was used without a "parent" class Changed to use as class

fixes #728