### PR TITLE
chore: Update Graalvm version in GitHub workflows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -56,8 +56,8 @@ jobs:
       - name: 🥸 Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
-          java-version: '17'
+          java-version: '17.0.7'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
@@ -74,7 +74,7 @@ jobs:
           disk-root: "C:"
         if: ${{ matrix.os == 'windows-latest' }}
       - name: 🤳 Run native tests
-        run: mvn ${{ matrix.os == 'windows-latest' && '--%' || '' }} install -Pnative -Dquarkus.log.category.\"io.kaoto.backend.model.deployment.kamelet.step.FlowStepDeserializer\".level=OFF
+        run: mvn ${{ matrix.os == 'windows-latest' && '--%' || '' }} install -Pnative -Dquarkus.native.native-image-xmx=5g -Dquarkus.log.category.\"io.kaoto.backend.model.deployment.kamelet.step.FlowStepDeserializer\".level=OFF
       - name: Archive Quarkus log for native tests
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/generate-docker-image.yml
+++ b/.github/workflows/generate-docker-image.yml
@@ -36,7 +36,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: 🤳 Build Native Quarkus
-        run: mvn -B install -Pnative
+        run: mvn -B install -Pnative -Dquarkus.native.native-image-xmx=5g
       - name: 📤 Login to DockerHub
         uses: docker/login-action@v2
         env:
@@ -100,8 +100,8 @@ jobs:
       - name: 🥸 Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
-          version: '22.3.0'
+          java-version: '17.0.7'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 🔥 Cache Maven packages

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: 🥸 Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
-          version: '22.3.0'
+          java-version: '17.0.7'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
@@ -45,7 +45,7 @@ jobs:
           disk-root: "C:"
         if: ${{ matrix.os == 'windows-latest' }}
       - name: 🤳 Build Native Quarkus
-        run: mvn install -Pnative -DskipTests
+        run: mvn install -Pnative -Dquarkus.native.native-image-xmx=5g -DskipTests
       - name: 🛂 Find the version - non-Windows
         run: 'echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV'
         if: ${{ matrix.os != 'windows-latest' }}


### PR DESCRIPTION
https://github.com/graalvm/setup-graalvm#migrating-from-graalvm-223-or-earlier-to-the-new-graalvm-for-jdk-17-and-later