### PR TITLE
fix: Integration CRD: Missing multiple route support

### DIFF
--- a/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
@@ -371,7 +371,8 @@ class IntegrationsResourceTest {
     @ParameterizedTest
     @ValueSource(strings = {"Camel Route#route-multi.yaml", "KameletBinding#kamelet-binding-multi.yaml",
             "Kamelet#eip.kamelet.yaml", "Kamelet#kamelet-multi.yaml", "Camel Route#rest-dsl-multi.yaml",
-            "Camel Route#route-with-beans.yaml", "Integration#integration.yaml"})
+            "Camel Route#route-with-beans.yaml", "Integration#integration.yaml",
+            "Integration#integration-multiroute.yaml"})
     void roundTrip(String file) throws IOException {
 
         String[] parameters = file.split("#");
@@ -467,7 +468,8 @@ class IntegrationsResourceTest {
     @ParameterizedTest
     @ValueSource(strings = {"Kamelet#eip.kamelet.yaml", "Integration#integration.yaml",
             "Camel Route#route-with-beans.yaml", "Camel Route#rest-dsl-multi.yaml",
-            "KameletBinding#kamelet-binding.yaml", "Kamelet#kamelet2.yaml"})
+            "KameletBinding#kamelet-binding.yaml", "Kamelet#kamelet2.yaml",
+            "Integration#integration-multiroute.yaml"})
     void changeNameAndDescription(String file) throws IOException {
 
         String[] parameters = file.split("#");
@@ -528,9 +530,9 @@ class IntegrationsResourceTest {
         switch (parameters[0]) {
             case "Kamelet":
             case "Kamelet Binding":
-            case "Integration":
                 assertTrue(sourceCode.contains("  name: " + randomGeneratedName));
                 break;
+            case "Integration":
             case "Camel Route":
                 assertTrue(sourceCode.contains("    id: " + randomGeneratedName));
                 break;

--- a/api/src/test/resources/io/kaoto/backend/api/resource/integration-multiroute.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/integration-multiroute.yaml
@@ -1,0 +1,28 @@
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: multiroute-integration-example
+spec:
+  flows:
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: '5000'
+        steps:
+        - to:
+            uri: activemq:queue:myQueue
+        - to:
+            uri: log:save
+  - route:
+      id: timer-amq-log2
+      from:
+        uri: timer:tick2
+        parameters:
+          period: '5000'
+        steps:
+        - to:
+            uri: activemq:queue:myQueue2
+        - to:
+            uri: log:save2

--- a/api/src/test/resources/io/kaoto/backend/api/resource/integration.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/integration.yaml
@@ -6,15 +6,17 @@ spec:
   dependencies:
   - mvn:something.something
   flows:
-  - from:
-      uri: timer:tick
-      parameters:
-        period: '5000'
-      steps:
-      - to:
-          uri: activemq:queue:myQueue
-      - to:
-          uri: log:save
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: '5000'
+        steps:
+        - to:
+            uri: activemq:queue:myQueue
+        - to:
+            uri: log:save
   integrationKit:
     apiVersion: patatas
     fieldPath: fieldPathy

--- a/camel-route-support/src/main/java/io/kaoto/backend/api/service/step/parser/camelroute/FlowDeserializer.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/api/service/step/parser/camelroute/FlowDeserializer.java
@@ -1,0 +1,55 @@
+package io.kaoto.backend.api.service.step.parser.camelroute;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.kaoto.backend.model.deployment.kamelet.Flow;
+import io.kaoto.backend.model.deployment.kamelet.step.From;
+import io.kaoto.backend.model.deployment.rest.Rest;
+
+public class FlowDeserializer extends StdDeserializer<Flow> {
+    protected FlowDeserializer() {
+        this(null);
+    }
+
+    protected FlowDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Flow deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        Flow flow = new Flow();
+        var root = p.getCodec().readTree(p);
+        if (((ObjectNode)root).has("route")) {
+            var route = ((ObjectNode)root).get("route");
+            if (route.has("id")) {
+                flow.setId(route.get("id").asText());
+            }
+            if (route.has("route-configuration-id")) {
+                flow.setRouteConfigurationId(route.get("route-configuration-id").asText());
+            }
+            if (route.has("description")) {
+                flow.setDescription(route.get("description").asText());
+            }
+            if (route.has("from")) {
+                var from = ctxt.readTreeAsValue(route.get("from"), From.class);
+                flow.setFrom(from);
+            }
+        }
+        if (((ObjectNode)root).has("from")) {
+            var from = ctxt.readTreeAsValue((JsonNode)root.get("from"), From.class);
+            flow.setFrom(from);
+        }
+        if (((ObjectNode)root).has("rest")) {
+            var rest = ctxt.readTreeAsValue((JsonNode)root.get("rest"), Rest.class);
+            flow.setRest(rest);
+        }
+        return flow;
+    }
+}

--- a/camel-route-support/src/main/java/io/kaoto/backend/model/deployment/camelroute/IntegrationFlow.java
+++ b/camel-route-support/src/main/java/io/kaoto/backend/model/deployment/camelroute/IntegrationFlow.java
@@ -1,0 +1,59 @@
+package io.kaoto.backend.model.deployment.camelroute;
+
+import java.util.List;
+import java.util.Map;
+
+import io.kaoto.backend.model.parameter.Parameter;
+import io.kaoto.backend.model.step.Step;
+
+public class IntegrationFlow {
+    private List<Step> steps;
+    private List<Parameter> parameters;
+    private Map<String, Object> metadata;
+
+    public List<Step> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(final List<Step> steps) {
+        this.steps = steps;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(final Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    public List<Parameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(
+            final List<Parameter> parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IntegrationFlow that)) return false;
+
+        if (getSteps() != null ? !getSteps().equals(that.getSteps()) : that.getSteps() != null) return false;
+        if (getParameters() != null ? !getParameters().equals(that.getParameters()) : that.getParameters() != null)
+            return false;
+        return getMetadata() != null ? getMetadata().equals(that.getMetadata()) : that.getMetadata() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getSteps() != null ? getSteps().hashCode() : 0;
+        result = 31 * result + (getParameters() != null ? getParameters().hashCode() : 0);
+        result = 31 * result + (getMetadata() != null ? getMetadata().hashCode() : 0);
+        return result;
+    }
+}
+
+

--- a/camel-route-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/camelroute/DeploymentGeneratorServiceTest.java
+++ b/camel-route-support/src/test/java/io/kaoto/backend/api/service/deployment/generator/camelroute/DeploymentGeneratorServiceTest.java
@@ -68,20 +68,14 @@ class DeploymentGeneratorServiceTest {
                 "      steps:",
                 "      - to:",
                 "          uri: log:tick",
-                "---",
-                "apiVersion: camel.apache.org/v1",
-                "kind: Integration",
-                "metadata:",
-                "  name: bye.yaml",
-                "spec:",
-                "  flows:",
                 "  - from:",
                 "      uri: timer:tock",
                 "      parameters:",
                 "        period: '3000'",
                 "      steps:",
                 "      - to:",
-                "          uri: log:tock")) + System.lineSeparator();
+                "          uri: log:tock"
+)) + System.lineSeparator();
 
         var parsed = stepParserService.getParsedFlows(yaml);
 

--- a/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/IntegrationStepParserServiceTest.java
+++ b/camel-route-support/src/test/java/io/kaoto/backend/api/service/step/parser/camelroute/IntegrationStepParserServiceTest.java
@@ -59,6 +59,29 @@ class IntegrationStepParserServiceTest {
         assertThat(yaml).isEqualToNormalizingNewlines(integration);
     }
 
+    @Test
+    void parseMultipleRoutes() throws Exception {
+        String input = new String(Objects.requireNonNull(
+                this.getClass().getResourceAsStream("integration-multiroute.yaml"))
+                .readAllBytes(), StandardCharsets.UTF_8);
+        var parsed = service.getParsedFlows(input);
+        assertThat(parsed).hasSize(3);
+        var metadata = parsed.get(0);
+        assertThat(metadata.getSteps()).isNull();
+        assertThat(metadata.getParameters()).isEmpty();
+        assertThat(metadata.getMetadata().get("name")).isEqualTo("multiroute-integration-example");
+        var flow1 = parsed.get(1);
+        assertThat(flow1.getMetadata().get("name")).isEqualTo("timer-amq-log");
+        assertThat(flow1.getParameters()).isEmpty();
+        assertThat(flow1.getSteps()).extracting(Step::getName).containsExactly("timer", "activemq", "log");
+        var flow2 = parsed.get(2);
+        assertThat(flow2.getMetadata().get("name")).isEqualTo("timer-amq-log2");
+        assertThat(flow2.getParameters()).isEmpty();
+        assertThat(flow2.getSteps()).extracting(Step::getName).containsExactly("timer", "activemq", "log");
+        var yaml = deploymentService.parse(parsed);
+        assertThat(yaml).isEqualToNormalizingNewlines(input);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"invalid/dropbox-sink.kamelet.yaml", "invalid/twitter-search-source-binding.yaml",
             "route.yaml"})

--- a/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/integration-multiroute.yaml
+++ b/camel-route-support/src/test/resources/io/kaoto/backend/api/service/step/parser/camelroute/integration-multiroute.yaml
@@ -1,0 +1,28 @@
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: multiroute-integration-example
+spec:
+  flows:
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: '5000'
+        steps:
+        - to:
+            uri: activemq:queue:myQueue
+        - to:
+            uri: log:save
+  - route:
+      id: timer-amq-log2
+      from:
+        uri: timer:tick2
+        parameters:
+          period: '5000'
+        steps:
+        - to:
+            uri: activemq:queue:myQueue2
+        - to:
+            uri: log:save2


### PR DESCRIPTION
Fixes: #733

Now `New route` button successfully adds a new route inside the existing Integration CRD
![Screenshot from 2023-06-29 20-48-45](https://github.com/KaotoIO/kaoto-backend/assets/265462/05bbcede-f531-4eef-9bd8-66e1cd9b1c33)

