### PR TITLE
fix: All parameters can be substituted by string variables

### DIFF
--- a/api/src/main/java/io/kaoto/backend/api/service/deployment/DeploymentService.java
+++ b/api/src/main/java/io/kaoto/backend/api/service/deployment/DeploymentService.java
@@ -87,9 +87,7 @@ public class DeploymentService {
                             .parse(i.getSteps(), i.getMetadata(), i.getParameters());
                 }
             } catch (Exception e) {
-                log.warn("Parser " + parser.getClass() + "threw an unexpected"
-                                + " error. ",
-                        e);
+                log.warn("Parser " + parser.getClass() + "threw an unexpected error. ", e);
             }
         }
 

--- a/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
@@ -372,7 +372,7 @@ class IntegrationsResourceTest {
             "Camel Route#route-with-beans.yaml", "Integration#integration.yaml",
             "Integration#integration-multiroute.yaml", "Kamelet#jms-amqp-10-source.kamelet.yaml",
             "Integration#integration-no-step.yaml", "Integration#integration-with-beans.yaml",
-            "Kamelet#beans.kamelet.yaml"})
+            "Kamelet#beans.kamelet.yaml", "Kamelet#aws-cloudtrail.yaml"})
     void roundTrip(String file) throws IOException {
 
         String[] parameters = file.split("#");

--- a/api/src/test/resources/io/kaoto/backend/api/resource/aws-cloudtrail.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/aws-cloudtrail.yaml
@@ -1,0 +1,31 @@
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  annotations:
+    camel.apache.org/kamelet.icon: whatever
+  labels:
+    camel.apache.org/kamelet.type: source
+  name: eip-source
+spec:
+  definition:
+    properties: {}
+    title: AWS-Cloudtrail
+  dependencies:
+  - camel:core
+  - camel:kamelet
+  - camel:aws-cloudtrail
+  template:
+    from:
+      uri: aws-cloudtrail:cloudtrail
+      parameters:
+        secretKey: '{{?secretKey}}'
+        accessKey: '{{?accessKey}}'
+        maxResults: '{{maxResults}}'
+        overrideEndpoint: '{{overrideEndpoint}}'
+        eventSource: '{{?eventSource}}'
+        uriEndpointOverride: '{{?uriEndpointOverride}}'
+        useDefaultCredentialsProvider: '{{useDefaultCredentialsProvider}}'
+        region: '{{region}}'
+      steps:
+      - to:
+          uri: kamelet:sink

--- a/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
@@ -431,9 +431,15 @@ public class KamelPopulator {
                         if (value != null) {
                             uri.append(value);
                         }
-                    } else if (value != null && !p.getId().equalsIgnoreCase("step-id-kaoto")
-                            && !p.convertToType(value).equals(p.getDefaultValue())) {
-                        params.put(p.getId(), p.convertToType(value));
+                    } else {
+                        final var typedValue = p.convertToType(value);
+                        if (value != null && !p.getId().equalsIgnoreCase("step-id-kaoto")) {
+                            if (typedValue != null && !typedValue.equals(p.getDefaultValue())) {
+                                params.put(p.getId(), typedValue);
+                            } else if (typedValue == null && value != null) {
+                                params.put(p.getId(), value);
+                            }
+                        }
                     }
                 }
             }

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
@@ -344,10 +344,14 @@ public class KameletStepParserService implements StepParserService<Step> {
             boolean found = false;
             for (Parameter p : step.getParameters()) {
                 if (p.getId().equalsIgnoreCase(key)) {
-                    if (!p.convertToType(value).equals(p.getDefaultValue())) {
-                        p.setValue(p.convertToType(value));
-                        found = true;
+                    final var typedValue = p.convertToType(value);
+                    if (typedValue != null && !typedValue.equals(p.getDefaultValue())) {
+                        p.setValue(typedValue);
+                    } else if (typedValue == null && value != null) {
+                        //It may be a string with a variable, for example
+                        p.setValue(value);
                     }
+                    found = true;
                     break;
                 }
             }

--- a/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/DoCatch.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/model/deployment/kamelet/step/DoCatch.java
@@ -10,6 +10,7 @@ import io.kaoto.backend.model.step.Branch;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -26,7 +27,13 @@ public class DoCatch implements Serializable {
         var exception = branch.getParameters().stream().filter(p -> p.getId().equalsIgnoreCase("exceptions")).findAny();
         if (exception.isPresent()) {
             setExceptions(new LinkedList<>());
-            Arrays.stream((Object[]) exception.get().getValue()).forEach(v -> getExceptions().add(String.valueOf(v)));
+            var list = Collections.emptyList();
+            if (exception.get().getValue() instanceof List<?>) {
+                list = (List<Object>) exception.get().getValue();
+            } else if (exception.get().getValue() instanceof Object[]) {
+                list = Arrays.asList((Object[]) exception.get().getValue());
+            }
+            list.forEach(v -> getExceptions().add(String.valueOf(v)));
         }
         var onW = branch.getParameters().stream().filter(p -> p.getId().equalsIgnoreCase("on-when")).findAny();
         if (onW.isPresent()) {

--- a/model/src/main/java/io/kaoto/backend/model/parameter/BooleanParameter.java
+++ b/model/src/main/java/io/kaoto/backend/model/parameter/BooleanParameter.java
@@ -23,11 +23,14 @@ public class BooleanParameter extends Parameter<Boolean> {
 
     @Override
     public Boolean convertToType(final Object value) {
-        try {
-            return Boolean.valueOf(String.valueOf(value));
-        } catch (Exception e) {
+        if ("true".equalsIgnoreCase(String.valueOf(value))) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(String.valueOf(value))) {
             return false;
         }
+        return null;
+
     }
 
     @Override

--- a/model/src/main/java/io/kaoto/backend/model/parameter/Parameter.java
+++ b/model/src/main/java/io/kaoto/backend/model/parameter/Parameter.java
@@ -38,7 +38,7 @@ public abstract class Parameter<T> implements Cloneable, Comparable<Parameter<T>
     private Integer pathOrder = 0;
     @JsonIgnore
     private String pathSeparator = ":";
-    private T value;
+    private Object value;
 
     //JSON schema
     private String title;
@@ -117,11 +117,11 @@ public abstract class Parameter<T> implements Cloneable, Comparable<Parameter<T>
      * Used when describing a configured element.
      *
      */
-    public T getValue() {
+    public Object getValue() {
         return this.value;
     }
 
-    public void setValue(final T value) {
+    public void setValue(final Object value) {
         this.value = value;
     }
 


### PR DESCRIPTION
{{variables}} in fields that are not string were not recognized. We are failing to recognize them, chocking, and then we no longer know how to deal with the step at all.

Plus, booleans were not properly detected. 

Fixes #721