### PR TITLE
Enum and example are kept on Kamelets and right type of Kamelet detected

### DIFF
--- a/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
@@ -372,7 +372,8 @@ class IntegrationsResourceTest {
             "Camel Route#route-with-beans.yaml", "Integration#integration.yaml",
             "Integration#integration-multiroute.yaml", "Kamelet#jms-amqp-10-source.kamelet.yaml",
             "Integration#integration-no-step.yaml", "Integration#integration-with-beans.yaml",
-            "Kamelet#beans.kamelet.yaml", "Kamelet#aws-cloudtrail.yaml"})
+            "Kamelet#beans.kamelet.yaml", "Kamelet#aws-cloudtrail.yaml",
+            "Kamelet#avro-serialize-action.kamelet.yaml"})
     void roundTrip(String file) throws IOException {
 
         String[] parameters = file.split("#");

--- a/api/src/test/resources/io/kaoto/backend/api/resource/avro-serialize-action.kamelet.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/avro-serialize-action.kamelet.yaml
@@ -1,0 +1,100 @@
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  annotations:
+    camel.apache.org/kamelet.support.level: Stable
+    camel.apache.org/catalog.version: 3.20.7-SNAPSHOT
+    camel.apache.org/kamelet.icon: data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgdmlld0JveD0iMCAtMjU2IDE3OTIgMTc5MiIKICAgaWQ9InN2ZzMwMjUiCiAgIHZlcnNpb249IjEuMSIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMC40OC4zLjEgcjk4ODYiCiAgIHdpZHRoPSIxMDAlIgogICBoZWlnaHQ9IjEwMCUiCiAgIHNvZGlwb2RpOmRvY25hbWU9ImNvZ19mb250X2F3ZXNvbWUuc3ZnIj4KICA8bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGEzMDM1Ij4KICAgIDxyZGY6UkRGPgogICAgICA8Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+CiAgICAgICAgPGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+CiAgICAgICAgPGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPgogICAgICA8L2NjOldvcms+CiAgICA8L3JkZjpSREY+CiAgPC9tZXRhZGF0YT4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzAzMyIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIgogICAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICAgIGJvcmRlcm9wYWNpdHk9IjEiCiAgICAgb2JqZWN0dG9sZXJhbmNlPSIxMCIKICAgICBncmlkdG9sZXJhbmNlPSIxMCIKICAgICBndWlkZXRvbGVyYW5jZT0iMTAiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9IjY0MCIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSI0ODAiCiAgICAgaWQ9Im5hbWVkdmlldzMwMzEiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGlua3NjYXBlOnpvb209IjAuMTMxNjk2NDMiCiAgICAgaW5rc2NhcGU6Y3g9Ijg5NiIKICAgICBpbmtzY2FwZTpjeT0iODk2IgogICAgIGlua3NjYXBlOndpbmRvdy14PSIwIgogICAgIGlua3NjYXBlOndpbmRvdy15PSIyNSIKICAgICBpbmtzY2FwZTp3aW5kb3ctbWF4aW1pemVkPSIwIgogICAgIGlua3NjYXBlOmN1cnJlbnQtbGF5ZXI9InN2ZzMwMjUiIC8+CiAgPGcKICAgICB0cmFuc2Zvcm09Im1hdHJpeCgxLDAsMCwtMSwxMjEuNDkxNTMsMTI4NS40MjM3KSIKICAgICBpZD0iZzMwMjciPgogICAgPHBhdGgKICAgICAgIGQ9Im0gMTAyNCw2NDAgcSAwLDEwNiAtNzUsMTgxIC03NSw3NSAtMTgxLDc1IC0xMDYsMCAtMTgxLC03NSAtNzUsLTc1IC03NSwtMTgxIDAsLTEwNiA3NSwtMTgxIDc1LC03NSAxODEsLTc1IDEwNiwwIDE4MSw3NSA3NSw3NSA3NSwxODEgeiBtIDUxMiwxMDkgViA1MjcgcSAwLC0xMiAtOCwtMjMgLTgsLTExIC0yMCwtMTMgbCAtMTg1LC0yOCBxIC0xOSwtNTQgLTM5LC05MSAzNSwtNTAgMTA3LC0xMzggMTAsLTEyIDEwLC0yNSAwLC0xMyAtOSwtMjMgLTI3LC0zNyAtOTksLTEwOCAtNzIsLTcxIC05NCwtNzEgLTEyLDAgLTI2LDkgbCAtMTM4LDEwOCBxIC00NCwtMjMgLTkxLC0zOCAtMTYsLTEzNiAtMjksLTE4NiAtNywtMjggLTM2LC0yOCBIIDY1NyBxIC0xNCwwIC0yNC41LDguNSBRIDYyMiwtMTExIDYyMSwtOTggTCA1OTMsODYgcSAtNDksMTYgLTkwLDM3IEwgMzYyLDE2IFEgMzUyLDcgMzM3LDcgMzIzLDcgMzEyLDE4IDE4NiwxMzIgMTQ3LDE4NiBxIC03LDEwIC03LDIzIDAsMTIgOCwyMyAxNSwyMSA1MSw2Ni41IDM2LDQ1LjUgNTQsNzAuNSAtMjcsNTAgLTQxLDk5IEwgMjksNDk1IFEgMTYsNDk3IDgsNTA3LjUgMCw1MTggMCw1MzEgdiAyMjIgcSAwLDEyIDgsMjMgOCwxMSAxOSwxMyBsIDE4NiwyOCBxIDE0LDQ2IDM5LDkyIC00MCw1NyAtMTA3LDEzOCAtMTAsMTIgLTEwLDI0IDAsMTAgOSwyMyAyNiwzNiA5OC41LDEwNy41IDcyLjUsNzEuNSA5NC41LDcxLjUgMTMsMCAyNiwtMTAgbCAxMzgsLTEwNyBxIDQ0LDIzIDkxLDM4IDE2LDEzNiAyOSwxODYgNywyOCAzNiwyOCBoIDIyMiBxIDE0LDAgMjQuNSwtOC41IFEgOTE0LDEzOTEgOTE1LDEzNzggbCAyOCwtMTg0IHEgNDksLTE2IDkwLC0zNyBsIDE0MiwxMDcgcSA5LDkgMjQsOSAxMywwIDI1LC0xMCAxMjksLTExOSAxNjUsLTE3MCA3LC04IDcsLTIyIDAsLTEyIC04LC0yMyAtMTUsLTIxIC01MSwtNjYuNSAtMzYsLTQ1LjUgLTU0LC03MC41IDI2LC01MCA0MSwtOTggbCAxODMsLTI4IHEgMTMsLTIgMjEsLTEyLjUgOCwtMTAuNSA4LC0yMy41IHoiCiAgICAgICBpZD0icGF0aDMwMjkiCiAgICAgICBpbmtzY2FwZTpjb25uZWN0b3ItY3VydmF0dXJlPSIwIgogICAgICAgc3R5bGU9ImZpbGw6Y3VycmVudENvbG9yIiAvPgogIDwvZz4KPC9zdmc+Cg=="
+    camel.apache.org/provider: Apache Software Foundation
+    camel.apache.org/kamelet.group: Actions
+    camel.apache.org/kamelet.namespace: Transformation
+  labels:
+    camel.apache.org/kamelet.type: sink
+  name: avro-serialize-action
+spec:
+  definition:
+    description: Serialize payload to Avro
+    properties:
+      schema:
+        description: The Avro schema to use during serialization
+        example: '{"type": "record", "namespace": "com.example", "name": "FullName",
+          "fields": [{"name": "first", "type": "string"},{"name": "last", "type":
+          "string"}]}'
+        title: Schema
+        type: string
+      validate:
+        default: true
+        description: Indicates if the content must be validated against the schema
+        title: Validate
+        type: boolean
+      region:
+        description: The AWS region to access.
+        enum:
+        - ap-south-1
+        - eu-south-1
+        - us-gov-east-1
+        - me-central-1
+        - ca-central-1
+        - eu-central-1
+        - us-iso-west-1
+        - us-west-1
+        - us-west-2
+        - af-south-1
+        - eu-north-1
+        - eu-west-3
+        - eu-west-2
+        - eu-west-1
+        - ap-northeast-3
+        - ap-northeast-2
+        - ap-northeast-1
+        - me-south-1
+        - sa-east-1
+        - ap-east-1
+        - cn-north-1
+        - us-gov-west-1
+        - ap-southeast-1
+        - ap-southeast-2
+        - us-iso-east-1
+        - ap-southeast-3
+        - us-east-1
+        - us-east-2
+        - cn-northwest-1
+        - us-isob-east-1
+        - aws-global
+        - aws-cn-global
+        - aws-us-gov-global
+        - aws-iso-global
+        - aws-iso-b-global
+        title: AWS Region
+        type: string
+    required:
+    - schema
+    title: Avro Serialize Action
+    type: object
+  dependencies:
+  - github:apache.camel-kamelets:camel-kamelets-utils:3.20.7-SNAPSHOT
+  - camel:kamelet
+  - camel:core
+  - camel:jackson-avro
+  template:
+    from:
+      uri: kamelet:source
+      steps:
+      - set-property:
+          constant: '{{schema}}'
+          name: schema
+      - set-property:
+          constant: '{{validate}}'
+          name: validate
+      - marshal:
+          avro:
+            library: Jackson
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
+            schemaResolver: '#class:org.apache.camel.kamelets.utils.serialization.InflightAvroSchemaResolver'
+      - remove-property:
+          name: schema
+      - remove-property:
+          name: validate
+      - set-header:
+          constant: application/avro
+          name: Content-Type

--- a/api/src/test/resources/io/kaoto/backend/api/resource/avro-serialize-action.kamelet.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/avro-serialize-action.kamelet.yaml
@@ -9,7 +9,7 @@ metadata:
     camel.apache.org/kamelet.group: Actions
     camel.apache.org/kamelet.namespace: Transformation
   labels:
-    camel.apache.org/kamelet.type: sink
+    camel.apache.org/kamelet.type: action
   name: avro-serialize-action
 spec:
   definition:

--- a/api/src/test/resources/io/kaoto/backend/api/resource/eip.kamelet.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/eip.kamelet.yaml
@@ -223,5 +223,3 @@ spec:
                 uri: direct
                 parameters:
                   name: start
-      - to:
-          uri: kamelet:sink

--- a/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/KamelPopulator.java
@@ -348,18 +348,18 @@ public class KamelPopulator {
     }
 
     private Type defineType(final List<Step> steps) {
-        // The code of a "source" Kamelet must send data to the kamelet:sink
-        // special endpoint. The code of a "sink" Kamelet must consume data
-        // from the special endpoint kamelet:source.
-        // If it has both, it is an action.
+        //    source ends with a to that is a kamelet:sink or starts with an uri in the from
+        //    sink ends with a to that is NOT a kamelet:sink (a camel connector)
+        //    action anything else
         Type type = Type.action;
         if (steps.size() > 1) {
-            boolean source = steps.get(0).getName().equalsIgnoreCase("kamelet:source");
-            boolean sink = steps.get(steps.size() - 1).getName().equalsIgnoreCase("kamelet:sink");
-
-            if (source && !sink) {
+            if (steps.size() > 2
+                    && steps.get(steps.size() - 1).getKind().equalsIgnoreCase("Camel-Connector")
+                    && !steps.get(steps.size() - 1).getName().equalsIgnoreCase("kamelet:sink")) {
                 type = Type.sink;
-            } else if (!source && sink) {
+            } else if (steps.get(steps.size() - 1).getName().equalsIgnoreCase("kamelet:sink")
+                || steps.get(0).getKind().equalsIgnoreCase("Camel-Connector")
+                      && !steps.get(0).getName().equalsIgnoreCase("kamelet:source")) {
                 type = Type.source;
             }
         }

--- a/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
+++ b/kamelet-support/src/main/java/io/kaoto/backend/api/service/step/parser/kamelet/KameletStepParserService.java
@@ -133,7 +133,11 @@ public class KameletStepParserService implements StepParserService<Step> {
                                 def.getTitle(),
                                 def.getDescription(),
                                 def.getNullable(),
-                                def.get_enum() != null ? def.get_enum().toArray(new String[]{}) : null,
+                                def.get_enum() != null ?
+                                        def.get_enum().stream()
+                                                .map(anyType -> String.valueOf(anyType.getValue()))
+                                                .toArray(String[]::new):
+                                        null,
                                 def.getExample() != null ?
                                         new String[]{String.valueOf(def.getExample().getValue())} :
                                         null,
@@ -144,7 +148,10 @@ public class KameletStepParserService implements StepParserService<Step> {
                     case "number":
                         p = new NumberParameter(key, def.getTitle(),
                                 def.getDescription(), def.getNullable(),
-                                def.get_enum() != null ? def.get_enum().toArray(new Double[]{}) : null,
+                                def.get_enum() != null ?
+                                        def.get_enum().stream()
+                                                .map(anyType -> String.valueOf(anyType.getValue()))
+                                                .toArray(Double[]::new) : null,
                                 def.getExample() != null ?
                                         new Number[]{Double.valueOf(String.valueOf(def.getExample().getValue()))} :
                                         null,
@@ -155,7 +162,10 @@ public class KameletStepParserService implements StepParserService<Step> {
                     case "integer":
                         p = new IntegerParameter(key, def.getTitle(),
                                 def.getDescription(), def.getNullable(),
-                                def.get_enum() != null ? def.get_enum().toArray(new Integer[]{}) : null,
+                                def.get_enum() != null ?
+                                        def.get_enum().stream()
+                                                .map(anyType -> String.valueOf(anyType.getValue()))
+                                                .toArray(Integer[]::new) : null,
                                 def.getExample() != null ?
                                         new Integer[]{Integer.valueOf(String.valueOf(def.getExample().getValue()))} :
                                         null,
@@ -165,7 +175,10 @@ public class KameletStepParserService implements StepParserService<Step> {
                     case "boolean":
                         p = new BooleanParameter(key, def.getTitle(),
                                 def.getDescription(), def.getNullable(),
-                                def.get_enum() != null ? def.get_enum().toArray(new Boolean[]{}) : null,
+                                def.get_enum() != null ?
+                                        def.get_enum().stream()
+                                                .map(anyType -> String.valueOf(anyType.getValue()))
+                                                .toArray(Boolean[]::new) : null,
                                 def.getExample() != null ?
                                         new Boolean[]{Boolean.valueOf(String.valueOf(def.getExample().getValue()))} :
                                         null,

--- a/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/eip.kamelet.yaml
+++ b/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/eip.kamelet.yaml
@@ -250,5 +250,3 @@ spec:
                 ignore-invalid-endpoint: true
                 allow-optimised-components: true
                 auto-start-components: true
-      - to:
-          uri: kamelet:sink

--- a/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/jq.kamelet.yaml
+++ b/kamelet-support/src/test/resources/io/kaoto/backend/api/service/step/parser/kamelet/jq.kamelet.yaml
@@ -63,5 +63,3 @@ spec:
             - set-header:
                 constant: TOPIC.APAC
                 name: kafka.OVERRIDE_TOPIC
-      - to:
-          uri: kamelet:sink


### PR DESCRIPTION
Added an example that combines both, based on the avro-serialize-action.

Fixes #720

Going to combine this with a Fixes #719 