### PR TITLE
fix: Empty camel routes should show basic skeleton

### DIFF
--- a/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
+++ b/api/src/test/java/io/kaoto/backend/api/resource/v2/IntegrationsResourceTest.java
@@ -368,7 +368,7 @@ class IntegrationsResourceTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"Camel Route#route-multi.yaml", "KameletBinding#kamelet-binding-multi.yaml",
-            "Kamelet#eip.kamelet.yaml", "Camel Route#rest-dsl-multi.yaml",
+            "Kamelet#eip.kamelet.yaml", "Camel Route#rest-dsl-multi.yaml", "Camel Route#empty-route.yaml",
             "Camel Route#route-with-beans.yaml", "Integration#integration.yaml",
             "Integration#integration-multiroute.yaml", "Kamelet#jms-amqp-10-source.kamelet.yaml",
             "Integration#integration-no-step.yaml", "Integration#integration-with-beans.yaml",

--- a/api/src/test/resources/io/kaoto/backend/api/resource/empty-route.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/empty-route.yaml
@@ -1,0 +1,5 @@
+- route:
+    id: empty-route
+    from:
+      uri: null
+      steps: []


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto-ui/issues/2056

Something like 
```
- route:
    id: empty-route
    from:
      uri: null
      steps: []
```

Should return the same when pass through the API.