### PR TITLE
fix(native-build): Fix windows native build

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,7 +45,10 @@ jobs:
           disk-root: "C:"
         if: ${{ matrix.os == 'windows-latest' }}
       - name: 🤳 Build Native Quarkus
-        run: mvn install -Pnative -Dquarkus.native.native-image-xmx=5g -DskipTests
+        # Until https://github.com/PowerShell/PowerShell/issues/6291 is done, we cannot use -Dquarkus.native.native-image-xmx=5g
+        run: mvn install -Pnative -DskipTests
+        env:
+          QUARKUS_NATIVE_NATIVE_IMAGE_XMX: "5g"
       - name: 🛂 Find the version - non-Windows
         run: 'echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV'
         if: ${{ matrix.os != 'windows-latest' }}


### PR DESCRIPTION
### Context
Currently, there's an [open issue on Powershell](https://github.com/PowerShell/PowerShell/issues/6291) that causes an argument that starts with '-' (dash) and has a '.' (dot) in it, gets parsed as two separate arguments, i.e.:

```bash
> mvn install -Dquarkus.native.native-image-xmx=5g
```

gets parsed as

```bash
mvn install -Dquarkus .native.native-image-xmx=5g
```

This makes the native build fail since that is not a valid command.

### Changes
The workaround is to use the corresponding ENV variable to pass the same property in the meantime
