### PR TITLE
Update the script to do releases to avoid generating a tag that links nowhere in main

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-#git reset --hard 
-#git pull
+echo "MAKE SURE YOU ARE ON LATEST MAIN"
 
 echo "Enter version of Kaoto to release:"
 echo "Example: 1.0.0"
@@ -15,9 +14,13 @@ read -r gitPush
 
 if [ "$gitPush" = "y" ];
 then
-  echo "Enter the name of the fork (git remote -v can help you here)"
+  echo "Enter the local name of the fork (git remote -v can help you here)"
   echo "Example: upstream"
   read -r gitFork
+  
+  echo "Enter the url of the fork (git remote -v can help you here)"
+  echo "Example: https://github.com/YOUR_NAME/kaoto-backend"
+  read -r gitUrl
 fi
 
 echo "Do you want to download the latest zips of steps? (y/n)"
@@ -85,7 +88,7 @@ fi
 
 mvn versions:set -DnewVersion=$version
 git add .
-git commit -m "Updating to version $version"
+git commit -m "chore(release): Updating to version $version"
 
 if [ "$gitPush" = "y" ];
 then
@@ -97,7 +100,7 @@ echo "(SNAPSHOT will be added automatically)"
 echo "Example: 1.0.1"
 read -r version2
 
-git checkout -b release-$version2
+git checkout -b prepare-for-$version2
 mvn versions:set -DnewVersion="$version2"-SNAPSHOT
 git add .
 git commit -m "chore(release): Updating to version $version2-SNAPSHOT"
@@ -107,11 +110,18 @@ then
   git push $gitFork
 fi
 
+
 echo ""
 echo "Check the git log and if you like what you see, create pull requests"
 echo "for both branches release-$version and release-$version2."
+if [ "$gitPush" = "y" ];
+then
+  echo "Those pull requests could be found in:"
+  echo "$gitUrl/pull/new/release-$version"
+  echo "$gitUrl/pull/new/prepare-for-$version2"
+fi
 echo ""
-echo "Once the pull requests are merged, you can tag the version where release-$version is."
+echo "Once the pull requests are merged, you can tag the version where release-$version HEAD is."
 echo "Creating the tag will trigger the release creation."
 echo ""
 echo "Finally, go to https://github.com/KaotoIO/kaoto-backend/releases/ to review"


### PR DESCRIPTION
Now it pushes to your fork (if you provide it) and gives you the links to create the pull requests (if you provide the url of your fork).

But it won't generate the tag. That's for when the PRs are merged.