### PR TITLE
fix: Missing "txt" for the resource name

### DIFF
--- a/camel-support/src/main/java/io/kaoto/backend/camel/metadata/parser/step/camelroute/CamelRestDSLParseCatalog.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/metadata/parser/step/camelroute/CamelRestDSLParseCatalog.java
@@ -38,7 +38,7 @@ public class CamelRestDSLParseCatalog implements StepCatalogParser {
 
     private static final String ICON = KamelHelper.loadResourceAsString(
         CamelRestDSLParseCatalog.class,
-        "base64icon").orElse("");
+        "base64icon.txt").orElse("");
 
     @NotNull
     private static Step getRestParentStep() {


### PR DESCRIPTION
fixes: https://github.com/KaotoIO/kaoto-ui/issues/2180