### PR TITLE
feat: build standalone images

### DIFF
--- a/.github/workflows/generate-docker-image.yml
+++ b/.github/workflows/generate-docker-image.yml
@@ -172,3 +172,21 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  standalone:
+    uses: ./.github/workflows/standalone-build-and-push.yml
+    needs:
+      - build
+      - build-for-mac
+      - docker-for-mac
+    if: ${{ github.event_name != 'pull_request' }}
+    with:
+      tag: "${{ github.ref_name }}-${{ github.sha }}"
+      alias: "latest"
+      frontend-version: main
+      backend-version: main
+    secrets:
+      docker-username: ${{ secrets.DOCKER_USERNAME }}
+      docker-password: ${{ secrets.DOCKER_PASSWORD }}
+      quay-username: ${{ secrets.QUAY_USERNAME }}
+      quay-password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/publish-standalone-release.yml
+++ b/.github/workflows/publish-standalone-release.yml
@@ -1,0 +1,28 @@
+name: Publish Standalone Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend-version:
+        required: true
+        type: string
+      frontend-version:
+        required: true
+        type: string
+      standalone-version:
+        required: true
+        type: string
+
+jobs:
+  build:
+    uses: ./.github/workflows/standalone-build-and-push.yml
+    with:
+      tag: ${{ inputs.standalone-version }}
+      alias: "stable"
+      frontend-version: ${{ inputs.frontend-version }}
+      backend-version: ${{ inputs.backend-version }}
+    secrets:
+      docker-username: ${{ secrets.DOCKER_USERNAME }}
+      docker-password: ${{ secrets.DOCKER_PASSWORD }}
+      quay-username: ${{ secrets.QUAY_USERNAME }}
+      quay-password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/standalone-build-and-push.yml
+++ b/.github/workflows/standalone-build-and-push.yml
@@ -1,0 +1,105 @@
+name: Standalone Build And Push
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      alias:
+        required: true
+        type: string
+      backend-version:
+        required: true
+        type: string
+      frontend-version:
+        required: true
+        type: string
+    secrets:
+      docker-username:
+        required: true
+      docker-password:
+        required: true
+      quay-username:
+        required: true
+      quay-password:
+        required: true
+
+env:
+  KAOTO_TAG: ${{ inputs.tag }}
+  UI_TAG: ${{ inputs.frontend-version }}
+  API_TAG:  ${{ inputs.backend-version }}
+  MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -DskipTests=true -e
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant:
+        - native
+        - jvm
+    steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: 17
+        check-latest: true
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+      with:
+        repository: KaotoIO/kaoto-backend
+        ref: ${{ inputs.backend-version }}
+    - name: 'Build Container Image (${{ matrix.variant }})'
+      run: |
+        ./mvnw ${MAVEN_ARGS} clean install \
+          -Dpmd.skip=true \
+          -DskipTests \
+          -P${{ matrix.variant }} \
+          -Pcontainer-image \
+          -Pstandalone \
+          -Dkaoto.ui.branch=${{ inputs.frontend-version }} \
+          -Dquarkus.container-image.tag=${{ inputs.tag }}-${{ matrix.variant }} \
+          -Dquarkus.container-image.additional-tags=${{ inputs.alias }}-${{ matrix.variant }}
+    - name: Run built image
+      run: |
+        docker images
+        docker run -d --rm -p 8081:8081 --name kaoto-standalone kaotoio/standalone:${{ inputs.tag }}-${{ matrix.variant }}
+    - name: List running images
+      run: |
+        docker ps -a
+    - name: Check the deployed service URL
+      run: |
+        curl --fail -sv --retry 15 --retry-delay 1 --retry-all-errors http://localhost:8081/q/health
+
+    #
+    # DockerHub
+    #
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.docker-username }}
+        password: ${{ secrets.docker-password }}
+    - name: 'Push Images to DockerHub'
+      run: |
+        docker push docker.io/kaotoio/standalone --all-tags
+
+    #
+    # Quay
+    #
+    - name: Login to Quay.io
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.quay-username }}
+        password: ${{ secrets.quay-password }}
+    - name: Tag Quay images
+      run: |
+        docker tag kaotoio/standalone:${{ inputs.tag }}-${{ matrix.variant }} quay.io/kaotoio/standalone:${{ inputs.tag }}-${{ matrix.variant }}
+        docker tag kaotoio/standalone:${{ inputs.tag }}-${{ matrix.variant }} quay.io/kaotoio/standalone:${{ inputs.alias }}-${{ matrix.variant }}
+
+    - name: 'Push Images to Quay.io'
+      run: |
+        docker push quay.io/kaotoio/standalone --all-tags


### PR DESCRIPTION
This trigger standalone image when:
- a PR is merged and the main branch build successfully
- when the publish-standalone-release workflow is triggered (it is not possible to add it to the release action of the backedn because the action is triggered automatically when a release is created but for standalone we must set the related UI tag/version)