### PR TITLE
feat(rest): Add camelCase and kebab-case parsing

### DIFF
--- a/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/camelroute/CamelRoute.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/camelroute/CamelRoute.java
@@ -132,11 +132,21 @@ public class CamelRoute {
     }
 
     private void processConfigs(final Map<String, Object> metadata) {
-        if (metadata != null && metadata.containsKey("route-configuration")) {
+        if (metadata == null) {
+            return;
+        }
+
+        if (metadata.containsKey("route-configuration")) {
             setRouteConfiguration(metadata.get("route-configuration"));
         }
-        if (metadata != null && metadata.containsKey("rest-configuration")) {
+        if (metadata.containsKey("routeConfiguration")) {
+            setRouteConfiguration(metadata.get("routeConfiguration"));
+        }
+        if (metadata.containsKey("rest-configuration")) {
             setRestConfiguration(metadata.get("rest-configuration"));
+        }
+        if (metadata.containsKey("restConfiguration")) {
+            setRestConfiguration(metadata.get("restConfiguration"));
         }
     }
 

--- a/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/camelroute/CamelRouteSerializer.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/camelroute/CamelRouteSerializer.java
@@ -31,12 +31,12 @@ class CamelRouteSerializer extends StdSerializer<CamelRoute> {
         }
         if (route.getRouteConfiguration() != null) {
             Map<String, Object> config = new LinkedHashMap<>();
-            config.put("route-configuration", route.getRouteConfiguration());
+            config.put("routeConfiguration", route.getRouteConfiguration());
             properties.add(config);
         }
         if (route.getRestConfiguration() != null) {
             Map<String, Object> config = new LinkedHashMap<>();
-            config.put("rest-configuration", route.getRestConfiguration());
+            config.put("restConfiguration", route.getRestConfiguration());
             properties.add(config);
         }
         jsonGenerator.writeObject(properties);

--- a/camel-support/src/main/java/io/kaoto/backend/camel/service/step/parser/camelroute/CamelRouteDeserializer.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/service/step/parser/camelroute/CamelRouteDeserializer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
@@ -55,13 +56,17 @@ public class CamelRouteDeserializer extends StdDeserializer<CamelRoute> {
                     answer.setBeans(new ArrayList<>(beans.size()));
                 }
                 answer.getBeans().addAll(beans);
-            }  else if (field.has("route-configuration")) {
-                Object config = ctxt.readTreeAsValue(field.get("route-configuration"), Object.class);
+            } else if (field.has("routeConfiguration") || field.has("route-configuration")) {
+                JsonNode routeConfig = Objects.requireNonNullElse(
+                        field.get("routeConfiguration"), field.get("route-configuration"));
+                Object config = ctxt.readTreeAsValue(routeConfig, Object.class);
                 if (answer.getRouteConfiguration() == null) {
                     answer.setRouteConfiguration(config);
                 }
-            }   else if (field.has("rest-configuration")) {
-                Object config = ctxt.readTreeAsValue(field.get("rest-configuration"), Object.class);
+            } else if (field.has("restConfiguration") || field.has("rest-configuration")) {
+                JsonNode restConfig = Objects.requireNonNullElse(field.get("restConfiguration"),
+                        field.get("rest-configuration"));
+                Object config = ctxt.readTreeAsValue(restConfig, Object.class);
                 if (answer.getRestConfiguration() == null) {
                     answer.setRestConfiguration(config);
                 }

--- a/camel-support/src/main/java/io/kaoto/backend/camel/service/step/parser/camelroute/CamelRouteStepParserService.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/service/step/parser/camelroute/CamelRouteStepParserService.java
@@ -127,10 +127,10 @@ public class CamelRouteStepParserService implements StepParserService<Step> {
         ParseResult<Step> res = new ParseResult<>();
         Map<String, Object> metadata = new LinkedHashMap<>();
         if (route.getRestConfiguration() != null) {
-            metadata.put("rest-configuration", route.getRestConfiguration());
+            metadata.put("restConfiguration", route.getRestConfiguration());
         }
         if (route.getRouteConfiguration() != null) {
-            metadata.put("route-configuration", route.getRouteConfiguration());
+            metadata.put("routeConfiguration", route.getRouteConfiguration());
         }
         res.setMetadata(metadata);
         if (!res.getMetadata().isEmpty()) {

--- a/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/rest-dsl.yaml
+++ b/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/rest-dsl.yaml
@@ -1,4 +1,4 @@
-- rest-configuration:
+- restConfiguration:
     component: servlet
     bindingMode: auto
     inlineRoutes: true

--- a/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/route-with-id.yaml
+++ b/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/route-with-id.yaml
@@ -1,4 +1,4 @@
-- route-configuration:
+- routeConfiguration:
     id: yamlError
     on-exception:
     - on-exception:


### PR DESCRIPTION
### Context
Currently, routeConfiguration and restConfiguration properties are supported.

### Changes
The goal is to have both camelCase and kebab-case reading support but camelCase writing support.

`rest-configuration` and `route-configuration` gets transformed into `restConfiguration` and `routeConfiguration` respectively.