### PR TITLE
fix(build): Add flag for native build to use older instructions

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ quarkus:
       group-id: org.apache.camel.k
       artifact-id: camel-k-crds
   native:
-    additional-build-args: -H:ResourceConfigurationFiles=resources-config.json
+    additional-build-args: -H:ResourceConfigurationFiles=resources-config.json,-march=compatibility
   application:
     name: kaoto-backend
   http:


### PR DESCRIPTION
### Context
After upgrading to Quarkus v3.2, compiling to native targets use [recent CPU features](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.2#native-compilation---work-around-missing-cpu-features)

This commit adds the following flag to recover the previous behavior:

```
quarkus.native.additional-build-args=-march=compatibility
```

More info [here](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.2#native-compilation---work-around-missing-cpu-features)

fixes: https://github.com/KaotoIO/kaoto-backend/issues/852