### PR TITLE
fix: Rest verb/uri has been renamed to path

### DIFF
--- a/api/src/test/resources/io/kaoto/backend/api/resource/rest-dsl-multi.yaml
+++ b/api/src/test/resources/io/kaoto/backend/api/resource/rest-dsl-multi.yaml
@@ -4,7 +4,7 @@
     post:
     - consumes: application/json,application/xml
       id: addPet
-      uri: /pet
+      path: /pet
       param:
       - dataType: boolean
         defaultValue: false
@@ -20,7 +20,7 @@
         uri: direct:addPet
     - consumes: application/x-www-form-urlencoded
       id: updatePetWithForm
-      uri: /pet/{petId}
+      path: /pet/{petId}
       param:
       - dataType: integer
         name: petId
@@ -42,7 +42,7 @@
     - consumes: multipart/form-data
       id: uploadFile
       produces: application/json
-      uri: /pet/{petId}/uploadImage
+      path: /pet/{petId}/uploadImage
       param:
       - dataType: integer
         name: petId
@@ -64,7 +64,7 @@
     - consumes: '*/*'
       id: placeOrder
       produces: application/xml,application/json
-      uri: /store/order
+      path: /store/order
       param:
       - name: body
         description: order placed for purchasing the pet
@@ -74,7 +74,7 @@
         uri: direct:placeOrder
     - consumes: '*/*'
       id: createUser
-      uri: /user
+      path: /user
       description: This can only be done by the logged in user.
       param:
       - name: body
@@ -85,7 +85,7 @@
         uri: direct:createUser
     - consumes: '*/*'
       id: createUsersWithArrayInput
-      uri: /user/createWithArray
+      path: /user/createWithArray
       param:
       - name: body
         description: List of user object
@@ -95,7 +95,7 @@
         uri: direct:createUsersWithArrayInput
     - consumes: '*/*'
       id: createUsersWithListInput
-      uri: /user/createWithList
+      path: /user/createWithList
       param:
       - name: body
         description: List of user object
@@ -106,7 +106,7 @@
     get:
     - id: findPetsByStatus
       produces: application/xml,application/json
-      uri: /pet/findByStatus
+      path: /pet/findByStatus
       description: Multiple status values can be provided with comma separated strings
       param:
       - arrayType: string
@@ -120,7 +120,7 @@
         uri: direct:findPetsByStatus
     - id: findPetsByTags
       produces: application/xml,application/json
-      uri: /pet/findByTags
+      path: /pet/findByTags
       description: Muliple tags can be provided with comma separated strings.
       param:
       - arrayType: string
@@ -134,7 +134,7 @@
         uri: direct:findPetsByTags
     - id: getPetById
       produces: application/xml,application/json
-      uri: /pet/{petId}
+      path: /pet/{petId}
       description: Returns a single pet
       param:
       - dataType: integer
@@ -146,13 +146,13 @@
         uri: direct:getPetById
     - id: getInventory
       produces: application/json
-      uri: /store/inventory
+      path: /store/inventory
       description: Returns a map of status codes to quantities
       to:
         uri: direct:getInventory
     - id: getOrderById
       produces: application/xml,application/json
-      uri: /store/order/{orderId}
+      path: /store/order/{orderId}
       description: For valid response try integer IDs with value >= 1 and <= 10.
       param:
       - dataType: integer
@@ -164,7 +164,7 @@
         uri: direct:getOrderById
     - id: loginUser
       produces: application/xml,application/json
-      uri: /user/login
+      path: /user/login
       param:
       - dataType: string
         name: username
@@ -179,12 +179,12 @@
       to:
         uri: direct:loginUser
     - id: logoutUser
-      uri: /user/logout
+      path: /user/logout
       to:
         uri: direct:logoutUser
     - id: getUserByName
       produces: application/xml,application/json
-      uri: /user/{username}
+      path: /user/{username}
       param:
       - dataType: string
         name: username
@@ -195,7 +195,7 @@
         uri: direct:getUserByName
     delete:
     - id: deletePet
-      uri: /pet/{petId}
+      path: /pet/{petId}
       param:
       - dataType: string
         name: api_key
@@ -209,7 +209,7 @@
       to:
         uri: direct:deletePet
     - id: deleteOrder
-      uri: /store/order/{orderId}
+      path: /store/order/{orderId}
       description: For valid response try integer IDs with positive integer value.
       param:
       - dataType: integer
@@ -220,7 +220,7 @@
       to:
         uri: direct:deleteOrder
     - id: deleteUser
-      uri: /user/{username}
+      path: /user/{username}
       description: This can only be done by the logged in user.
       param:
       - dataType: string
@@ -233,7 +233,7 @@
     put:
     - consumes: application/json,application/xml
       id: updatePet
-      uri: /pet
+      path: /pet
       param:
       - name: body
         required: true
@@ -242,7 +242,7 @@
         uri: direct:updatePet
     - consumes: '*/*'
       id: updateUser
-      uri: /user/{username}
+      path: /user/{username}
       param:
       - dataType: string
         name: username

--- a/camel-support/src/main/java/io/kaoto/backend/camel/metadata/parser/step/camelroute/CamelRestDSLParseCatalog.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/metadata/parser/step/camelroute/CamelRestDSLParseCatalog.java
@@ -156,7 +156,7 @@ public class CamelRestDSLParseCatalog implements StepCatalogParser {
         parameters.add(parameter);
 
         parameter = new StringParameter();
-        parameter.setId(Rest.URI_LABEL);
+        parameter.setId(Rest.PATH_LABEL);
         parameter.setDescription("Uri path of this endpoint");
         parameter.setTitle("Uri Path");
         parameter.setDefaultValue("/");

--- a/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/rest/HttpVerb.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/rest/HttpVerb.java
@@ -27,8 +27,8 @@ public class HttpVerb implements Serializable {
     @JsonProperty("id")
     private String id;
 
-    @JsonProperty("uri")
-    private String uri;
+    @JsonProperty("path")
+    private String path;
     @JsonProperty(KamelHelper.DESCRIPTION)
     private String description;
 
@@ -58,12 +58,12 @@ public class HttpVerb implements Serializable {
         this.id = id;
     }
 
-    public String getUri() {
-        return uri;
+    public String getPath() {
+        return path;
     }
 
-    public void setUri(String uri) {
-        this.uri = uri;
+    public void setPath(String path) {
+        this.path = path;
     }
 
     public List<RestParameter> getParameterList() {

--- a/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/rest/HttpVerbSerializer.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/rest/HttpVerbSerializer.java
@@ -29,8 +29,8 @@ public class HttpVerbSerializer extends StdSerializer<HttpVerb> {
         if (data.getId() != null) {
             props.put("id", data.getId());
         }
-        if (data.getUri() != null) {
-            props.put("uri", data.getUri());
+        if (data.getPath() != null) {
+            props.put("path", data.getPath());
         }
         if (data.getDescription() != null) {
             props.put(KamelHelper.DESCRIPTION, data.getDescription());

--- a/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/rest/Rest.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/rest/Rest.java
@@ -43,7 +43,6 @@ import java.util.Map;
 public class Rest extends From {
     public static final String CONSUMES_LABEL = "consumes";
     public static final String PRODUCES_LABEL = "produces";
-    public static final String URI_LABEL = "uri";
     public static final String ID_LABEL = "id";
     public static final String PATH_LABEL = "path";
     public static final String GET_LABEL = "get";
@@ -419,8 +418,8 @@ public class Rest extends From {
                     httpVerb.setDescription(String.valueOf(p.getValue()));
                 } else if (p.getId().equalsIgnoreCase(ID_LABEL)) {
                     httpVerb.setId(String.valueOf(p.getValue()));
-                } else if (p.getId().equalsIgnoreCase(URI_LABEL)) {
-                    httpVerb.setUri(String.valueOf(p.getValue()));
+                } else if (p.getId().equalsIgnoreCase(PATH_LABEL)) {
+                    httpVerb.setPath(String.valueOf(p.getValue()));
                 } else if (PARAM_LABEL.equalsIgnoreCase(p.getId())) {
                     httpVerb.setParameterList(new ArrayList<>());
                     for (var value : (List) p.getValue()) {
@@ -589,7 +588,7 @@ public class Rest extends From {
     private Branch createBranchConsumes(StepCatalog catalog, KameletStepParserService ksps,
                                         HttpVerb endpoint) {
         Branch b = new Branch();
-        b.setIdentifier(endpoint.getUri() + " " + endpoint.getConsumes());
+        b.setIdentifier(endpoint.getPath() + " " + endpoint.getConsumes());
         var step = catalog.getReadOnlyCatalog().searchByID(Rest.CAMEL_REST_CONSUMES);
         if (step != null) {
             b.getSteps().add(step);
@@ -600,9 +599,9 @@ public class Rest extends From {
                 } else if (param.getId().equalsIgnoreCase(PRODUCES_LABEL)
                         && endpoint.getProduces() != null) {
                     param.setValue(endpoint.getProduces());
-                } else if (param.getId().equalsIgnoreCase(URI_LABEL)
-                        && endpoint.getUri() != null) {
-                    param.setValue(endpoint.getUri());
+                } else if (param.getId().equalsIgnoreCase(PATH_LABEL)
+                        && endpoint.getPath() != null) {
+                    param.setValue(endpoint.getPath());
                 } else if (param.getId().equalsIgnoreCase(ID_LABEL)
                         && endpoint.getId() != null) {
                     param.setValue(endpoint.getId());

--- a/camel-support/src/main/resources/io/kaoto/backend/camel/service/deployment/generator/camelroute/camel-yaml-dsl.json
+++ b/camel-support/src/main/resources/io/kaoto/backend/camel/service/deployment/generator/camelroute/camel-yaml-dsl.json
@@ -8290,6 +8290,12 @@
       "templatedRoute" : {
         "$ref" : "#/items/definitions/org.apache.camel.model.TemplatedRouteDefinition"
       },
+      "rest-configuration" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestConfigurationDefinition"
+      },
+      "restConfiguration" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestConfigurationDefinition"
+      },
       "rest" : {
         "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestDefinition"
       }

--- a/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/rest-dsl.yaml
+++ b/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/rest-dsl.yaml
@@ -15,7 +15,7 @@
     get:
     - produces: "application/xml,application/json"
       id: findPetsByStatus
-      uri: /pet/findByStatus
+      path: /pet/findByStatus
       description: Multiple status values can be provided with comma separated strings
       param:
       - dataType: array
@@ -29,7 +29,7 @@
         uri: direct:findPetsByStatus
     - produces: "application/xml,application/json"
       id: findPetsByTags
-      uri: /pet/findByTags
+      path: /pet/findByTags
       description: Muliple tags can be provided with comma separated strings.
       param:
       - dataType: array
@@ -43,7 +43,7 @@
         uri: direct:findPetsByTags
     - produces: "application/xml,application/json"
       id: getPetById
-      uri: "/pet/{petId}"
+      path: "/pet/{petId}"
       description: Returns a single pet
       param:
       - dataType: integer
@@ -55,13 +55,13 @@
         uri: direct:getPetById
     - produces: application/json
       id: getInventory
-      uri: /store/inventory
+      path: /store/inventory
       description: Returns a map of status codes to quantities
       to:
         uri: direct:getInventory
     - produces: "application/xml,application/json"
       id: getOrderById
-      uri: "/store/order/{orderId}"
+      path: "/store/order/{orderId}"
       description: For valid response try integer IDs with value >= 1 and <= 10.
       param:
       - dataType: integer
@@ -73,7 +73,7 @@
         uri: direct:getOrderById
     - produces: "application/xml,application/json"
       id: loginUser
-      uri: /user/login
+      path: /user/login
       param:
       - dataType: string
         description: The user name for login
@@ -88,12 +88,12 @@
       to:
         uri: direct:loginUser
     - id: logoutUser
-      uri: /user/logout
+      path: /user/logout
       to:
         uri: direct:logoutUser
     - produces: "application/xml,application/json"
       id: getUserByName
-      uri: "/user/{username}"
+      path: "/user/{username}"
       param:
       - dataType: string
         description: The name that needs to be fetched. Use user1 for testing.
@@ -105,7 +105,7 @@
     post:
     - consumes: "application/json,application/xml"
       id: addPet
-      uri: /pet
+      path: /pet
       param:
       - dataType: boolean
         defaultValue: false
@@ -121,7 +121,7 @@
         uri: direct:addPet
     - consumes: application/x-www-form-urlencoded
       id: updatePetWithForm
-      uri: "/pet/{petId}"
+      path: "/pet/{petId}"
       param:
       - dataType: integer
         description: ID of pet that needs to be updated
@@ -143,7 +143,7 @@
     - consumes: multipart/form-data
       produces: application/json
       id: uploadFile
-      uri: "/pet/{petId}/uploadImage"
+      path: "/pet/{petId}/uploadImage"
       param:
       - dataType: integer
         description: ID of pet to update
@@ -165,7 +165,7 @@
     - consumes: '*/*'
       produces: "application/xml,application/json"
       id: placeOrder
-      uri: /store/order
+      path: /store/order
       param:
       - description: order placed for purchasing the pet
         name: body
@@ -175,7 +175,7 @@
         uri: direct:placeOrder
     - consumes: '*/*'
       id: createUser
-      uri: /user
+      path: /user
       description: This can only be done by the logged in user.
       param:
       - description: Created user object
@@ -186,7 +186,7 @@
         uri: direct:createUser
     - consumes: '*/*'
       id: createUsersWithArrayInput
-      uri: /user/createWithArray
+      path: /user/createWithArray
       param:
       - description: List of user object
         name: body
@@ -196,7 +196,7 @@
         uri: direct:createUsersWithArrayInput
     - consumes: '*/*'
       id: createUsersWithListInput
-      uri: /user/createWithList
+      path: /user/createWithList
       param:
       - description: List of user object
         name: body
@@ -207,7 +207,7 @@
     put:
     - consumes: "application/json,application/xml"
       id: updatePet
-      uri: /pet
+      path: /pet
       param:
       - name: body
         required: true
@@ -216,7 +216,7 @@
         uri: direct:updatePet
     - consumes: '*/*'
       id: updateUser
-      uri: "/user/{username}"
+      path: "/user/{username}"
       param:
       - dataType: string
         name: username
@@ -229,7 +229,7 @@
         uri: direct:updateUser
     delete:
     - id: deletePet
-      uri: "/pet/{petId}"
+      path: "/pet/{petId}"
       param:
       - dataType: string
         name: api_key
@@ -243,7 +243,7 @@
       to:
         uri: direct:deletePet
     - id: deleteOrder
-      uri: "/store/order/{orderId}"
+      path: "/store/order/{orderId}"
       description: For valid response try integer IDs with positive integer value.
       param:
       - dataType: integer
@@ -254,7 +254,7 @@
       to:
         uri: direct:deleteOrder
     - id: deleteUser
-      uri: "/user/{username}"
+      path: "/user/{username}"
       description: This can only be done by the logged in user.
       param:
       - dataType: string


### PR DESCRIPTION
Fixes: #854

From 3.16
https://camel.apache.org/manual/camel-3x-upgrade-guide-3_16.html#_renamed_uri_to_path