### PR TITLE
Revert "fix(build): Add flag for native build to use older instructions"

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ quarkus:
       group-id: org.apache.camel.k
       artifact-id: camel-k-crds
   native:
-    additional-build-args: -H:ResourceConfigurationFiles=resources-config.json,-march=compatibility
+    additional-build-args: -H:ResourceConfigurationFiles=resources-config.json
   application:
     name: kaoto-backend
   http:


### PR DESCRIPTION
Reverting this pull request as it seems to be the root cause for the docker generation image problem

Reverts KaotoIO/kaoto-backend#853