### PR TITLE
Revert "Revert "fix(build): Add flag for native build to use older instructions""

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ quarkus:
       group-id: org.apache.camel.k
       artifact-id: camel-k-crds
   native:
-    additional-build-args: -H:ResourceConfigurationFiles=resources-config.json
+    additional-build-args: -H:ResourceConfigurationFiles=resources-config.json,-march=compatibility
   application:
     name: kaoto-backend
   http:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <!-- Quarkus version -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.3.2</quarkus.platform.version>
+        <quarkus.platform.version>3.2.5.Final</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
 
         <!-- SonarCloud analysis -->


### PR DESCRIPTION
### Context
Currently, the standalone build for `jvm` is failing since there's a mismatch between the current of quarkus (3.3.2) and camel quarkus (3.2.5.Final).

In addition to that, the application fail to load in virtualized environments without enabling the legacy CPU instructions.

Reverts KaotoIO/kaoto-backend#856