### PR TITLE
fix: bindingMode: off is converted to bindingMode: false

### DIFF
--- a/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/camelroute/CamelRoute.java
+++ b/camel-support/src/main/java/io/kaoto/backend/camel/model/deployment/camelroute/CamelRoute.java
@@ -176,5 +176,18 @@ public class CamelRoute {
 
     public void setRestConfiguration(Object restConfiguration) {
         this.restConfiguration = restConfiguration;
+        if (!(restConfiguration instanceof Map)) {
+            return;
+        }
+        // YAML 1.1 assumes "off" to be a boolean "false", restore it as a string
+        var map = (Map<String, Object>) restConfiguration;
+        var camelBindingMode = map.get("bindingMode");
+        if (camelBindingMode instanceof Boolean && !((Boolean) camelBindingMode)) {
+            map.put("bindingMode", "off");
+        }
+        var kebabBindingMode = map.get("binding-mode");
+        if (kebabBindingMode instanceof Boolean && !((Boolean) camelBindingMode)) {
+            map.put("binding-mode", "off");
+        }
     }
 }

--- a/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/rest-dsl-bindingMode-off.yaml
+++ b/camel-support/src/test/resources/io/kaoto/backend/camel/service/step/parser/camelroute/rest-dsl-bindingMode-off.yaml
@@ -1,0 +1,25 @@
+- restConfiguration:
+    component: servlet
+    bindingMode: off
+    inlineRoutes: true
+    apiComponent: openapi
+- rest:
+    id: this-is-the-rest-definition
+    path: /api/v3
+    put:
+    - consumes: application/json,application/xml
+      id: updatePet
+      path: /pet
+      param:
+      - name: body
+        required: true
+        type: body
+      to:
+        uri: direct:updatePet
+- route:
+    id: from-route
+    from:
+      uri: direct:updatePet
+      steps:
+      - log:
+          message: ${body}


### PR DESCRIPTION
Fixes: #863

YAML 1.1 defines `off` to be a boolean `false`
https://yaml.org/type/bool.html

Adding a workaround to restore `off` as a string with a quote.

![Screenshot from 2023-09-15 14-22-06](https://github.com/KaotoIO/kaoto-backend/assets/265462/bafc4b05-1723-4cd7-9559-5833d5fc1d7d)

After Sync
![Screenshot from 2023-09-15 14-22-14](https://github.com/KaotoIO/kaoto-backend/assets/265462/837aeebd-d7cc-4692-a451-d1c0a85759b2)
